### PR TITLE
[Fix]  Add Dependency Review Step to Workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Export requirements.txt
         uses: Divkix/poetry-export-requirements-action@v1.4.0
 
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v3
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
+
   # Job for scheduled event
   dependency-review-scheduled:
     if: github.event_name == 'schedule'
@@ -48,3 +54,6 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v3
+        with:
+          base-ref: 'main'
+          head-ref: ${{ github.ref }}


### PR DESCRIPTION
**Title:** Add Dependency Review Step to Workflow

**Description:**

This PR introduces a crucial update to our GitHub Actions workflow. We've added the `Dependency Review` step to both the `dependency-review-pr` and `dependency-review-scheduled` jobs in our `.github/workflows/dependency-review.yml` file.

The `Dependency Review` step uses `actions/dependency-review-action@v3` and now includes the necessary `base-ref` and `head-ref` parameters. For pull request events, these references are dynamically set based on the pull request details or default to the 'main' branch. For scheduled events, the `base-ref` is set to 'main', and the `head-ref` is set to the current ref.

These changes ensure that our dependencies are reviewed correctly, whether the workflow is triggered by a pull request or a scheduled event. This will help us maintain the health and security of our project by keeping our dependencies up-to-date and identifying potential vulnerabilities.

Please review the changes and provide any feedback.