### PR TITLE
Don't count bot mentions as ghost pings

### DIFF
--- a/tux/cogs/utility/ghost_pings.py
+++ b/tux/cogs/utility/ghost_pings.py
@@ -19,6 +19,8 @@ class GhostPings(commands.Cog):
         if message.mentions or message.role_mentions:
             if len(message.mentions) == 1 and message.mentions[0] == message.author:
                 return
+            if len(message.mentions) == 1 and message.mentions[0].bot:
+                return
 
             embed = discord.Embed(
                 title="Ghost Ping!", color=discord.Color.red(), timestamp=message.created_at

--- a/tux/cogs/utility/ghost_pings.py
+++ b/tux/cogs/utility/ghost_pings.py
@@ -17,9 +17,7 @@ class GhostPings(commands.Cog):
 
         # check if message has a ping (role, user, etc.)
         if message.mentions or message.role_mentions:
-            if len(message.mentions) == 1 and message.mentions[0] == message.author:
-                return
-            if len(message.mentions) == 1 and message.mentions[0].bot:
+            if len(message.mentions) == 1 and (message.mentions[0] == message.author) or (message.mentions[0].bot):
                 return
 
             embed = discord.Embed(


### PR DESCRIPTION
If a user pings a bot and deletes the message, there is no need to trigger a ghost ping message because the mentioned user is a bot.