### PR TITLE
less spammy snippets style

### DIFF
--- a/tux/cogs/utility/snippets.py
+++ b/tux/cogs/utility/snippets.py
@@ -155,9 +155,7 @@ class Snippets(commands.Cog):
             await ctx.send(embed=embed)
             return
 
-        top_row = f"`/snippets/{snippet.name}.txt` |⦚| {self.bot.get_user(snippet.author_id) or 'Unknown Author'}"
-
-        text = f"{top_row}\n{snippet.content}"
+        text = f"`/snippets/{snippet.name}.txt` || {snippet.content}"
 
         await ctx.send(text, allowed_mentions=AllowedMentions.none())
 


### PR DESCRIPTION
removes the top row and only displays the snippet name and separator

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request simplifies the display format of snippets by removing the top row, which included the snippet path and author information, and now only shows the snippet name and content.

- **Enhancements**:
    - Simplified the snippet display by removing the top row and only showing the snippet name and content.

<!-- Generated by sourcery-ai[bot]: end summary -->