### PR TITLE
Add more time formats to `remindme` and make message ephemeral

### DIFF
--- a/tux/cogs/utility/remindme.py
+++ b/tux/cogs/utility/remindme.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import datetime
 
@@ -88,6 +89,10 @@ class RemindMe(commands.Cog):
         # Delete the reminder after sending
         await self.db_controller.reminders.delete_reminder(reminder.id)
 
+        # wait for a second so that the reminder is deleted before checking for more reminders
+        # who knows if this works, it seems to
+        await asyncio.sleep(1)
+
         # Run update again to check if there are any more reminders
         await self.update()
 
@@ -146,9 +151,9 @@ class RemindMe(commands.Cog):
         interaction : discord.Interaction
             The discord interaction object.
         time : str
-            The time to wait before reminding.
+            Time in the format `[number][M/w/d/h/m/s]`.
         reminder : str
-            The reminder message.
+            Reminder content.
         """
 
         seconds = convert_to_seconds(time)
@@ -156,7 +161,7 @@ class RemindMe(commands.Cog):
         # Check if the time is valid (this is set to 0 if the time is invalid via convert_to_seconds)
         if seconds == 0:
             await interaction.response.send_message(
-                "Invalid time format. Please use a format like `1d`, `2h`, `3m`, etc. (only days, hours, and minutes are supported)"
+                "Invalid time format. Please use the format `[number][M/w/d/h/m/s]`.",
             )
             return
 
@@ -191,7 +196,7 @@ class RemindMe(commands.Cog):
 
             logger.error(f"Error creating reminder: {e}")
 
-        await interaction.response.send_message(embed=embed)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
         # Run update again to check if this reminder is the closest
         await self.update()

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -7,7 +7,7 @@ import discord
 
 def convert_to_seconds(time_str: str) -> int:
     """
-    Converts a formatted time string with 'd' for days, 'h' for hours, 'm' for minutes, 'w' for weeks, and 'mo' for months to total seconds.
+    Converts a formatted time string with the formats Mwdhms
     Any unexpected format leads to returning 0.
 
     Parameters:

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -7,7 +7,7 @@ import discord
 
 def convert_to_seconds(time_str: str) -> int:
     """
-    Converts a formatted time string with 'd' for days, 'h' for hours, and 'm' for minutes into total seconds.
+    Converts a formatted time string with 'd' for days, 'h' for hours, 'm' for minutes, 'w' for weeks, and 'mo' for months to total seconds.
     Any unexpected format leads to returning 0.
 
     Parameters:
@@ -21,14 +21,14 @@ def convert_to_seconds(time_str: str) -> int:
         The total seconds from the formatted time string.
     """
 
-    # Lowercase to standardize the input
-    time_str = time_str.lower()
-
     # Time conversion factors from units to seconds
     time_units = {
+        "M": 2592000,  # Months to seconds
+        "w": 604800,  # Weeks to seconds
         "d": 86400,  # Days to seconds
         "h": 3600,  # Hours to seconds
         "m": 60,  # Minutes to seconds
+        "s": 1,  # Seconds to seconds
     }
 
     total_seconds = 0


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the `remindme` command by adding support for more time formats (months, weeks, seconds) and making reminder messages ephemeral. Additionally, it includes a minor delay to ensure reminders are deleted before checking for more reminders.

- **New Features**:
    - Added support for additional time formats (months, weeks, seconds) in the `remindme` command.
- **Enhancements**:
    - Made reminder messages ephemeral to ensure they are only visible to the user who set the reminder.

<!-- Generated by sourcery-ai[bot]: end summary -->