### PR TITLE
Added warning when `rm -rf ~`  is mentioned 

### DIFF
--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -5,8 +5,7 @@ from typing import Any
 
 import discord
 
-harmful_command_pattern = r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*(/\s*|\*|/bin|/boot|/etc|/lib|/proc|/root|/sbin|/sys|/tmp|/usr|/var|/var/log|/network.|/system)(\s+--no-preserve-root|\s+\*)*|:\(\)\{ :|:& \};:"
-
+harmful_command_pattern = r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*(~|\s*|\*|/bin|/boot|/etc|/lib|/proc|/root|/sbin|/sys|/tmp|/usr|/var|/var/log|/network.|/system)(\s+--no-preserve-root|\s+\*)*|:\(\)\{ :|:& \};:"
 
 def is_harmful(command: str) -> bool:
     first_test: bool = re.search(harmful_command_pattern, command) is not None

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -14,9 +14,12 @@ harmful_command_pattern = (
     r"|format\s+([A-Z]:|C:|D:|E:|F:|G:|H:|I:|J:|K:|L:|M:|N:|O:|P:|Q:|R:|S:|T:|U:|V:|W:|X:|Y:|Z:)"
 )
 
+
 def is_harmful(command: str) -> bool:
     first_test: bool = re.search(harmful_command_pattern, command) is not None
-    second_test: bool = re.search(r"rm.{0,5}[rfRF]", command) is not None or re.search(r"del\s+/[qsf]", command) is not None
+    second_test: bool = (
+        re.search(r"rm.{0,5}[rfRF]", command) is not None or re.search(r"del\s+/[qsf]", command) is not None
+    )
     return first_test and second_test
 
 

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -5,11 +5,20 @@ from typing import Any
 
 import discord
 
-harmful_command_pattern = r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*(~|\s*|\*|/bin|/boot|/etc|/lib|/proc|/root|/sbin|/sys|/tmp|/usr|/var|/var/log|/network.|/system)(\s+--no-preserve-root|\s+\*)*|:\(\)\{ :|:& \};:"
+import re
+
+# Extend the pattern to include harmful Windows command prompt commands
+harmful_command_pattern = (
+    r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*"
+    r"(/|\*|~|/bin|/boot|/etc|/lib|/proc|/root|/sbin|/sys|/tmp|/usr|/var|/var/log|/network.|/system)(\s+--no-preserve-root|\s+\*)*"
+    r"|:\(\)\{ :|:& \};:"
+    r"|del\s+/[qsf]\s+(\*|C:\\|C:\\Windows|C:\\System32|C:\\Users|C:\\Program Files|C:\\Program Files \(x86\))"
+    r"|format\s+([A-Z]:|C:|D:|E:|F:|G:|H:|I:|J:|K:|L:|M:|N:|O:|P:|Q:|R:|S:|T:|U:|V:|W:|X:|Y:|Z:)"
+)
 
 def is_harmful(command: str) -> bool:
     first_test: bool = re.search(harmful_command_pattern, command) is not None
-    second_test: bool = re.search(r"rm.{0,5}[rfRF]", command) is not None
+    second_test: bool = re.search(r"rm.{0,5}[rfRF]", command) is not None or re.search(r"del\s+/[qsf]", command) is not None
     return first_test and second_test
 
 

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -5,8 +5,6 @@ from typing import Any
 
 import discord
 
-import re
-
 # Extend the pattern to include harmful Windows command prompt commands
 harmful_command_pattern = (
     r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*"


### PR DESCRIPTION
I changed `tux/utils/functions.py` in the `harmful_command_pattern` so that it's noticed that this is also a harmful command like `sudo rm -rf /`

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the harmful command detection pattern to recognize `rm -rf ~` as a harmful command, enhancing the safety checks in the utility functions.

- **Enhancements**:
    - Extended the harmful command detection pattern to include `rm -rf ~` as a harmful command.

<!-- Generated by sourcery-ai[bot]: end summary -->