### PR TITLE
[commands] add role toggle command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,4 @@ repos:
     rev: v8.18.4
     hooks:
       - id: gitleaks
-
-  - repo: https://github.com/hija/clean-dotenv
-    rev: v0.0.7
-    hooks:
-      - id: clean-dotenv
-
 exclude: ".archive/"

--- a/tux/cogs/moderation/roles.py
+++ b/tux/cogs/moderation/roles.py
@@ -1,0 +1,46 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+from loguru import logger
+
+
+class Roles(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    roles = app_commands.Group(name="roles", description="Commands for managing roles.")
+
+    @roles.command(name="toggle")
+    @commands.has_permissions(manage_roles=True)
+    async def toggle_role(self, interaction: discord.Interaction, user: discord.Member, role: discord.Role) -> None:
+        """
+        Toggle a role for a user.
+
+        Parameters
+        ----------
+        interaction : discord.Interaction
+            The discord interaction object.
+        user : discord.Member
+            The user to toggle the role for.
+        role : discord.Role
+            The role to toggle.
+        """
+
+        if role in user.roles:
+            await user.remove_roles(role)
+            await interaction.response.send_message(
+                f"Removed role {role.mention} from {user.mention}",
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+            logger.info(f"{interaction.user} removed role {role.name} from {user}.")
+        else:
+            await user.add_roles(role)
+            await interaction.response.send_message(
+                f"Added role {role.mention} to {user.mention}",
+                allowed_mentions=discord.AllowedMentions.none(),
+            )
+            logger.info(f"{interaction.user} added role {role.name} to {user}.")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Roles(bot))


### PR DESCRIPTION
closes #99 

also removed clean-dotenv from the pre commit config as its breaking stuff, feel free to revert that part

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new role toggle command to the moderation cog, enabling role management for users with the appropriate permissions. Additionally, it removes the clean-dotenv hook from the pre-commit configuration to resolve breaking issues.

- **New Features**:
    - Introduced a new role toggle command in the moderation cog, allowing users with manage roles permission to add or remove a role from a specified user.
- **Chores**:
    - Removed clean-dotenv hook from the pre-commit configuration due to issues.

<!-- Generated by sourcery-ai[bot]: end summary -->