### PR TITLE
Improved the help command

### DIFF
--- a/tux/help.py
+++ b/tux/help.py
@@ -116,7 +116,7 @@ class TuxHelp(commands.HelpCommand):
         menu = ViewMenu(self.context, menu_type=ViewMenu.TypeEmbed)
         cog_groups = [d for d in os.listdir("./tux/cogs") if Path(f"./tux/cogs/{d}").is_dir() and d != "__pycache__"]
         for i in range(len(cog_groups)):
-            embed = self.embed_base(cog_groups[i] + " Commands", "\n")
+            embed = self.embed_base(cog_groups[i].capitalize() + " Commands", "\n")
             embed.set_footer(text=f"Use {self.prefix}help <command> or <sub-command> to learn about it.")
 
             if cog_groups[i] in command_categories:

--- a/tux/help.py
+++ b/tux/help.py
@@ -105,7 +105,7 @@ class TuxHelp(commands.HelpCommand):
             if cog_group not in command_categories:
                 command_categories[cog_group] = {}
             if cmd not in command_categories[cog_group]:
-                command_categories[cog_group][cmd] = f"**{cmd}** | "
+                command_categories[cog_group][cmd] = ""
 
             for subcmd in mapping_commands:
                 command_name = subcmd.name


### PR DESCRIPTION
Reworked the $help command to use a implementation that organises the menu by the folder it is in (Denoted as `cog_group` in the code), it creates one page per `cog_group` with all the commands in that folder listed in an identical style to how it was done before. The pages can be navigated by buttons beneath the embed.