### PR TITLE
Clarify the harmful message warning to actually explain why it may be harmful so ignorant people don't execute it out of negligence.

### DIFF
--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -26,7 +26,7 @@ class EventHandler(commands.Cog):
 
         if is_harmful(stripped_content):
             await message.reply(
-                "Warning: This command is potentially harmful. This will delete the directory and all of its contents. There is no undo button to this operation when executed. Make sure you understand this before executing this potentially harmful command. You have been warned. Please ignore this message if you believe to have recieved it in error.",
+                "Warning: This command is potentially harmful. This will remove the directory and all its contents. There is no undo to this operation. Be sure you understand this before executing this. You have been warned. Please ignore this message if you believe to have recieved it in error.",
             )
 
     @commands.Cog.listener()

--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -26,7 +26,7 @@ class EventHandler(commands.Cog):
 
         if is_harmful(stripped_content):
             await message.reply(
-                "Warning: This command is potentially harmful. Please avoid running it unless you're fully aware of it's operation. If this was a mistake, disregard this message.",
+                "Warning: This command is potentially harmful. This will delete the directory and all of its contents. There is no undo button to this operation when executed. Make sure you understand this before executing this potentially harmful command. You have been warned. Please ignore this message if you believe to have recieved it in error.",
             )
 
     @commands.Cog.listener()


### PR DESCRIPTION
what the title says

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Clarify the warning message for potentially harmful commands to better inform users about the irreversible consequences of executing them.

Enhancements:
- Improve the warning message for potentially harmful commands to clearly explain the consequences of executing such commands, emphasizing the irreversible nature of the operation.

<!-- Generated by sourcery-ai[bot]: end summary -->