### PR TITLE
Revert "Update harmful command filter"

### DIFF
--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 
 from tux.database.controllers import DatabaseController
-from tux.utils.functions import get_harmful_command_type, is_harmful, strip_formatting
+from tux.utils.functions import is_harmful, strip_formatting
 
 
 class EventHandler(commands.Cog):
@@ -25,22 +25,9 @@ class EventHandler(commands.Cog):
         stripped_content = strip_formatting(message.content)
 
         if is_harmful(stripped_content):
-            bad_command_type: str = get_harmful_command_type(stripped_content)
-            if bad_command_type == "rm":
-                await message.reply(
-                    "⚠️ **This command is likely harmful.**\n-# By running it, **all directory contents will be deleted. There is no undo.** Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it. [Learn more](<https://itsfoss.com/sudo-rm-rf/>)",
-                )
-            else:
-                await message.reply(
-                    f"⚠️ **This command may be harmful.** Please ensure you understand its effects before proceeding. If you received this message in error, please disregard it.",
-                )
-                await message.reply(
-                    "⚠️ **This command is likely harmful.**\n-# By running it, **all directory contents will be deleted. There is no undo.** Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it. [Learn more](<https://itsfoss.com/sudo-rm-rf/>)",
-                )
-            elif bad_command_type == "dd":
-                await message.reply(
-                    "⚠️ **This command is likely harmful.**\n-# By running it, **all data on the specified disk will be erased. There is no undo.** Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.",
-                )
+            await message.reply(
+                "-# ⚠️ **This command is likely harmful. By running it, all directory contents will be deleted. There is no undo. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
+            )
 
     @commands.Cog.listener()
     async def on_message_edit(self, before: discord.Message, after: discord.Message) -> None:

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -5,31 +5,12 @@ from typing import Any
 import discord
 
 harmful_command_pattern = r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*([/\∕~]\s*|\*|/bin|/boot|/etc|/lib|/proc|/root|/sbin|/sys|/tmp|/usr|/var|/var/log|/network.|/system)(\s+--no-preserve-root|\s+\*)*|:\(\)\{ :|:& \};:"  # noqa: RUF001
-harmful_dd_command_pattern = r"dd\s+if=\/dev\/(zero|random|urandom)\s+of=\/dev\/.*da.*"
 
 
 def is_harmful(command: str) -> bool:
     first_test: bool = re.search(harmful_command_pattern, command, re.IGNORECASE) is not None
     second_test: bool = re.search(r"rm.{0,5}[rfRF]", command, re.IGNORECASE) is not None
-    third_test: bool = re.search(r"X\s*=\s*/\s*&&\s*(sudo\s*)?rm\s*-\s*rf", command, re.IGNORECASE) is not None
-    ret: bool = first_test and second_test or third_test
-    if not ret:
-        # Check for a harmful dd command
-        ret = re.search(harmful_dd_command_pattern, command, re.IGNORECASE) is not None
-    return ret
-
-
-def get_harmful_command_type(command: str) -> str:
-    bad_command_type = ""
-    first_test: bool = re.search(harmful_command_pattern, command, re.IGNORECASE) is not None
-    second_test: bool = re.search(r"rm.{0,5}[rfRF]", command, re.IGNORECASE) is not None
-    third_test: bool = re.search(r"X\s*=\s*/\s*&&\s*(sudo\s*)?rm\s*-\s*rf", command, re.IGNORECASE) is not None
-    if first_test and second_test or third_test:
-        bad_command_type = "rm"
-    else:
-        if re.search(harmful_dd_command_pattern, command, re.IGNORECASE) is not None:
-            bad_command_type = "dd"
-    return bad_command_type
+    return first_test and second_test
 
 
 def strip_formatting(content: str) -> str:


### PR DESCRIPTION
Reverts allthingslinux/tux#403

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Revert the previous update to the harmful command filter by removing the differentiation between 'rm' and 'dd' command types, simplifying the logic for detecting harmful commands.

Enhancements:
- Simplify the harmful command detection logic by removing the differentiation between 'rm' and 'dd' command types.

<!-- Generated by sourcery-ai[bot]: end summary -->