### PR TITLE
Snippet Statistics

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,7 @@ model Snippet {
   snippet_created_at DateTime @default(now())
   guild_id           BigInt
   guild              Guild    @relation(fields: [guild_id], references: [guild_id])
+  uses               BigInt   @default(0)
 
   @@unique([snippet_name, guild_id])
   @@index([snippet_name, guild_id])

--- a/tux/cogs/utility/snippets.py
+++ b/tux/cogs/utility/snippets.py
@@ -102,6 +102,61 @@ class Snippets(commands.Cog):
         return embed
 
     @commands.command(
+        name="topsnippets",
+        aliases=["ts"],
+        usage="topsnippets",
+    )
+    @commands.guild_only()
+    async def top_snippets(self, ctx: commands.Context[commands.Bot]) -> None:
+        """
+        List top snippets by pagination.
+
+        Parameters
+        ----------
+        ctx : commands.Context[commands.Bot]
+            The context object.
+        """
+
+        # find the top 10 snippets by uses
+        snippets: list[Snippet] = await self.db.get_all_snippets()
+
+        # Remove snippets that are not in the current server
+        snippets = [snippet for snippet in snippets if snippet.guild_id == ctx.guild.id]  # type: ignore # because of guild_only this will never be None
+
+        # If there are no snippets, send an error message
+        if not snippets:
+            embed = EmbedCreator.create_error_embed(
+                title="Error",
+                description="No snippets found.",
+                ctx=ctx,
+            )
+            await ctx.send(embed=embed, delete_after=30)
+            return
+
+        # sort the snippets by uses
+        snippets.sort(key=lambda x: x.uses, reverse=True)
+
+        # print in this format
+        # 1. snippet_name | uses: 10
+        # 2. snippet_name | uses: 9
+        # 3. snippet_name | uses: 8
+        # ...
+
+        text = "```\n"
+        for i, snippet in enumerate(snippets[:10]):
+            text += f"{i+1}. {snippet.snippet_name.ljust(20)} | uses: {snippet.uses}\n"
+        text += "```"
+
+        # only show top 10, no pagination
+        embed = discord.Embed(
+            title="Top Snippets",
+            description=text,
+            color=CONST.EMBED_COLORS["DEFAULT"],
+        )
+
+        await ctx.send(embed=embed)
+
+    @commands.command(
         name="deletesnippet",
         aliases=["ds"],
         usage="deletesnippet [name]",
@@ -214,6 +269,9 @@ class Snippets(commands.Cog):
             await ctx.send(embed=embed, delete_after=30, ephemeral=True)
             return
 
+        # increment the usage count of the snippet
+        await self.db.increment_snippet_uses(snippet.snippet_id)
+
         text = f"`/snippets/{snippet.snippet_name}.txt` || {snippet.snippet_content}"
 
         await ctx.send(text, allowed_mentions=AllowedMentions.none())
@@ -263,6 +321,7 @@ class Snippets(commands.Cog):
         embed.add_field(name="Name", value=snippet.snippet_name, inline=False)
         embed.add_field(name="Author", value=f"{author.mention}", inline=False)
         embed.add_field(name="Content", value=f"> {snippet.snippet_content}", inline=False)
+        embed.add_field(name="Uses", value=snippet.uses, inline=False)
 
         embed.timestamp = snippet.snippet_created_at or datetime.datetime.fromtimestamp(
             0,

--- a/tux/cogs/utility/snippets.py
+++ b/tux/cogs/utility/snippets.py
@@ -109,7 +109,7 @@ class Snippets(commands.Cog):
     @commands.guild_only()
     async def top_snippets(self, ctx: commands.Context[commands.Bot]) -> None:
         """
-        List top snippets by pagination.
+        List top snippets.
 
         Parameters
         ----------

--- a/tux/database/controllers/snippet.py
+++ b/tux/database/controllers/snippet.py
@@ -63,3 +63,13 @@ class SnippetController:
             where={"snippet_id": snippet_id},
             data={"snippet_content": snippet_content},
         )
+
+    async def increment_snippet_uses(self, snippet_id: int) -> Snippet | None:
+        snippet = await self.table.find_first(where={"snippet_id": snippet_id})
+        if snippet is None:
+            return None
+
+        return await self.table.update(
+            where={"snippet_id": snippet_id},
+            data={"uses": snippet.uses + 1},
+        )


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a command to display the top 10 most used snippets in a server and enhance snippet information by including usage count. Implement functionality to increment the usage count of a snippet each time it is accessed.

New Features:
- Introduce a new command `topsnippets` to list the top 10 snippets by usage in the current server.

Enhancements:
- Add a field to display the usage count of a snippet in the snippet information embed.

<!-- Generated by sourcery-ai[bot]: end summary -->