### PR TITLE
feat(snippets.py) implement snippet locking

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model Snippet {
   guild_id           BigInt
   guild              Guild    @relation(fields: [guild_id], references: [guild_id])
   uses               BigInt   @default(0)
+  locked             Boolean  @default(false)
 
   @@unique([snippet_name, guild_id])
   @@index([snippet_name, guild_id])

--- a/tux/cogs/utility/snippets.py
+++ b/tux/cogs/utility/snippets.py
@@ -512,10 +512,7 @@ class Snippets(commands.Cog):
             await ctx.send(embed=embed, delete_after=30, ephemeral=True)
             return
 
-        # dm the author of the snippet
-        # if failed to dm just ignore it
-        author = self.bot.get_user(snippet.snippet_user_id)
-        if author:
+        if author := self.bot.get_user(snippet.snippet_user_id):
             with contextlib.suppress(discord.Forbidden):
                 await author.send(
                     f"""Your snippet `{snippet.snippet_name}` has been {'locked' if status.locked else 'unlocked'}.

--- a/tux/database/controllers/snippet.py
+++ b/tux/database/controllers/snippet.py
@@ -76,3 +76,25 @@ class SnippetController:
             where={"snippet_id": snippet_id},
             data={"uses": snippet.uses + 1},
         )
+
+    async def lock_snippet_by_id(self, snippet_id: int) -> Snippet | None:
+        return await self.table.update(
+            where={"snippet_id": snippet_id},
+            data={"locked": True},
+        )
+
+    async def unlock_snippet_by_id(self, snippet_id: int) -> Snippet | None:
+        return await self.table.update(
+            where={"snippet_id": snippet_id},
+            data={"locked": False},
+        )
+
+    async def toggle_snippet_lock_by_id(self, snippet_id: int) -> Snippet | None:
+        snippet = await self.table.find_first(where={"snippet_id": snippet_id})
+        if snippet is None:
+            return None
+
+        return await self.table.update(
+            where={"snippet_id": snippet_id},
+            data={"locked": not snippet.locked},
+        )


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce snippet locking to prevent unauthorized edits or deletions, and add a command to toggle snippet lock status with necessary permission checks.

New Features:
- Implement snippet locking functionality, allowing snippets to be locked to prevent unauthorized edits or deletions.

Enhancements:
- Add a command `togglesnippetlock` to toggle the lock status of a snippet, with appropriate permission checks.

<!-- Generated by sourcery-ai[bot]: end summary -->