### PR TITLE
feat(snippets.py) show lock emoji if snippet is locked

### DIFF
--- a/tux/cogs/utility/snippets.py
+++ b/tux/cogs/utility/snippets.py
@@ -289,7 +289,12 @@ class Snippets(commands.Cog):
         # increment the usage count of the snippet
         await self.db.increment_snippet_uses(snippet.snippet_id)
 
-        text = f"`/snippets/{snippet.snippet_name}.txt` || {snippet.snippet_content}"
+        # example text:
+        # `/snippets/name.txt` [if locked put '🔒 ' icon]|| [content]
+        text = f"`/snippets/{snippet.snippet_name}.txt` "
+        if snippet.locked:
+            text += "🔒 "
+        text += f"|| {snippet.snippet_content}"
 
         await ctx.send(text, allowed_mentions=AllowedMentions.none())
 


### PR DESCRIPTION
## Description

Fixes #471 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other: (write here)

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

i ran the snippet command for both locked and unlocked snippets

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a feature to show a lock emoji in the snippet display if the snippet is locked, enhancing the user interface to indicate locked snippets.

New Features:
- Display a lock emoji next to the snippet name if the snippet is locked.

<!-- Generated by sourcery-ai[bot]: end summary -->