### PR TITLE
feat: defer processing message instead of reply

### DIFF
--- a/tux/cogs/fun/imgeffect.py
+++ b/tux/cogs/fun/imgeffect.py
@@ -50,7 +50,7 @@ class ImgEffect(commands.Cog):
 
         # say that the image is being processed
         logger.info("Processing image...")
-        await interaction.response.defer("Processing image...")
+        await interaction.response.defer(ephemeral=True)
 
         # open url with PIL
         logger.info("Opening image with PIL and HTTPX...")
@@ -89,8 +89,8 @@ class ImgEffect(commands.Cog):
         pil_image.save(arr, format="JPEG", quality=1)
         arr.seek(0)
         file = discord.File(arr, filename="deepfried.jpg")
-        # edit message with image
-        await interaction.response.edit_message(content="Here is your deepfried image:", file=file)
+
+        await interaction.followup.send(file=file, ephemeral=True)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/tux/cogs/fun/imgeffect.py
+++ b/tux/cogs/fun/imgeffect.py
@@ -50,7 +50,7 @@ class ImgEffect(commands.Cog):
 
         # say that the image is being processed
         logger.info("Processing image...")
-        await interaction.response.send_message("Processing image...")
+        await interaction.response.defer("Processing image...")
 
         # open url with PIL
         logger.info("Opening image with PIL and HTTPX...")
@@ -90,7 +90,7 @@ class ImgEffect(commands.Cog):
         arr.seek(0)
         file = discord.File(arr, filename="deepfried.jpg")
         # edit message with image
-        await interaction.followup.send(content="Here is your deepfried image:", file=file)
+        await interaction.response.edit_message(content="Here is your deepfried image:", file=file)
 
 
 async def setup(bot: commands.Bot) -> None:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Defer the initial processing message and edit the message with the final image instead of sending a follow-up message, streamlining the interaction flow.

Enhancements:
- Defer the processing message instead of sending it immediately, improving user experience by indicating that the bot is working on the request.

<!-- Generated by sourcery-ai[bot]: end summary -->