### PR TITLE
Bookmarking messages

### DIFF
--- a/cogs/utility/bookmarks.py
+++ b/cogs/utility/bookmarks.py
@@ -1,0 +1,56 @@
+import discord
+from discord.ext import commands
+from loguru import logger
+
+from tux.utils.embeds import EmbedCreator
+
+
+class Bookmarks(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        if str(payload.emoji) == "🔖":
+            try:
+                channel = self.bot.get_channel(payload.channel_id)
+                if channel is None:
+                    logger.error("Channel not found")
+                    return
+
+                message = await channel.fetch_message(payload.message_id)
+                if message is None:
+                    logger.error("Message not found")
+                    return
+
+                embed = EmbedCreator.create_info_embed(
+                    title="Message Bookmarked",
+                    description=f"> {message.content}",
+                )
+                embed.add_field(name="Author", value=message.author.name, inline=False)
+                embed.add_field(name="Jump to Message", value=f"[Click Here]({message.jump_url})", inline=False)
+
+                if message.attachments:
+                    attachments_info = "\n".join([attachment.url for attachment in message.attachments])
+                    embed.add_field(name="Attachments", value=attachments_info, inline=False)
+
+                try:
+                    user = self.bot.get_user(payload.user_id)
+                    if user is not None:
+                        await user.send(embed=embed)
+                        await message.remove_reaction(payload.emoji, user)
+                    else:
+                        logger.error(f"User not found for ID: {payload.user_id}")
+                except (discord.Forbidden, discord.HTTPException):
+                    logger.error(f"Cannot send a DM to {user.name}. They may have DMs turned off.")
+                    await message.remove_reaction(payload.emoji, user)
+                    temp_message = await channel.send(
+                        f"{user.mention}, I couldn't send you a DM make sure your DMs are open for bookmarks to work",
+                    )
+                    await temp_message.delete(delay=30)
+            except (discord.NotFound, discord.Forbidden, discord.HTTPException) as e:
+                logger.error(f"Failed to process the reaction: {e}")
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Bookmarks(bot))


### PR DESCRIPTION
Description

Adds Bookmarking to tux whenever you react with 🔖 on a message in a server it gets linked and its contents forwarded to your dms
Type of Change

Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Breaking change (fix or feature that would cause existing functionality to not work as expected)
Documentation update

    Other: (write here)

Guidelines

    My code follows the style guidelines of this project (formatted with Ruff)

    I have performed a self-review of my own code

    I have commented my code, particularly in hard-to-understand areas

    I have made corresponding changes to the documentation if needed

    My changes generate no new warnings

    I have tested this change

    Any dependent changes have been merged and published in downstream modules

    I have followed all of these guidelines.

How Has This Been Tested? (if applicable)

Please describe how you tested your code. e.g describe what commands you ran, what arguments, and any config stuff (if applicable)
Screenshots (if applicable)

image
![image](https://github.com/user-attachments/assets/92f6d6f4-4336-4e24-a0b3-4dc57f3ffb81)

Please add screenshots to help explain your changes.
Additional Information

Please add any other information that is important to this PR.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new bookmarking feature that enables users to bookmark messages by reacting with a bookmark emoji, forwarding the message content to their direct messages.

New Features:
- Introduce a bookmarking feature that allows users to bookmark messages by reacting with a bookmark emoji, which sends the message content to the user's direct messages.

<!-- Generated by sourcery-ai[bot]: end summary -->