### PR TITLE
Add flagging functionality for moderation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,4 +169,6 @@ enum CaseType {
   UNJAIL
   SNIPPETUNBAN
   UNTEMPBAN
+  FLAG
+  UNFLAG
 }

--- a/tux/cogs/moderation/__init__.py
+++ b/tux/cogs/moderation/__init__.py
@@ -212,6 +212,7 @@ class ModerationCogBase(commands.Cog):
         reason: str,
         user: discord.Member | discord.User,
         dm_sent: bool,
+        silent_action: bool,
         duration: str | None = None,
     ):
         moderator = ctx.author
@@ -248,5 +249,7 @@ class ModerationCogBase(commands.Cog):
         else:
             embed.description = "DMs are disabled for this user or the silent flag was used."
 
-        await self.send_embed(ctx, embed, log_type="mod")
+        if not silent_action:
+            await self.send_embed(ctx, embed, log_type="mod")
+
         await ctx.send(embed=embed, delete_after=30, ephemeral=True)

--- a/tux/cogs/moderation/__init__.py
+++ b/tux/cogs/moderation/__init__.py
@@ -246,7 +246,7 @@ class ModerationCogBase(commands.Cog):
         if dm_sent:
             embed.description = "A DM has been sent to the user."
         else:
-            embed.description = "DMs are disabled for this user."
+            embed.description = "DMs are disabled for this user or the silent flag was used."
 
         await self.send_embed(ctx, embed, log_type="mod")
         await ctx.send(embed=embed, delete_after=30, ephemeral=True)

--- a/tux/cogs/moderation/ban.py
+++ b/tux/cogs/moderation/ban.py
@@ -69,7 +69,15 @@ class Ban(ModerationCogBase):
             guild_id=ctx.guild.id,
         )
 
-        await self.handle_case_response(ctx, CaseType.BAN, case.case_number, flags.reason, member, dm_sent, False)
+        await self.handle_case_response(
+            ctx,
+            CaseType.BAN,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            silent_action=False,
+        )
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/moderation/ban.py
+++ b/tux/cogs/moderation/ban.py
@@ -69,7 +69,7 @@ class Ban(ModerationCogBase):
             guild_id=ctx.guild.id,
         )
 
-        await self.handle_case_response(ctx, CaseType.BAN, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(ctx, CaseType.BAN, case.case_number, flags.reason, member, dm_sent, False)
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/moderation/cases.py
+++ b/tux/cogs/moderation/cases.py
@@ -25,6 +25,8 @@ emojis: dict[str, int] = {
     "jail": 1268115750392954880,
     "snippetban": 1277174953950576681,
     "snippetunban": 1277174953292337222,
+    "flag": 1275782294363312172,
+    "unflag": 1275782294363312172,
 }
 
 
@@ -381,6 +383,8 @@ class Cases(ModerationCogBase):
             CaseType.UNJAIL: "jail",
             CaseType.SNIPPETBAN: "snippetban",
             CaseType.SNIPPETUNBAN: "snippetunban",
+            CaseType.FLAG: "flag",
+            CaseType.UNFLAG: "unflag",
         }
         emoji_name = emoji_map.get(case_type)
         if emoji_name is not None:

--- a/tux/cogs/moderation/flag.py
+++ b/tux/cogs/moderation/flag.py
@@ -1,0 +1,93 @@
+import discord
+from discord.ext import commands
+
+from prisma.enums import CaseType
+from tux.bot import Tux
+from tux.database.controllers.case import CaseController
+from tux.utils import checks
+from tux.utils.flags import FlagFlags, generate_usage
+
+from . import ModerationCogBase
+
+
+class Flag(ModerationCogBase):
+    def __init__(self, bot: Tux) -> None:
+        super().__init__(bot)
+        self.case_controller = CaseController()
+        self.flag.usage = generate_usage(self.flag, FlagFlags)
+
+    @commands.hybrid_command(
+        name="flag",
+        aliases=["fl"],
+    )
+    @commands.guild_only()
+    @checks.has_pl(2)
+    async def flag(
+        self,
+        ctx: commands.Context[Tux],
+        member: discord.Member,
+        *,
+        flags: FlagFlags,
+    ) -> None:
+        """
+        Flag a member from the server.
+
+        Parameters
+        ----------
+        ctx : commands.Context[Tux]
+            The context in which the command is being invoked.
+        member : discord.Member
+            The member to flag.
+        flags : FlagFlags
+            The flags for the command. (reason: str, silent: bool)
+        """
+
+        assert ctx.guild
+
+        if await self.is_flagged(ctx.guild.id, member.id):
+            await ctx.send("User is already flagged.", delete_after=30, ephemeral=True)
+            return
+
+        moderator = ctx.author
+
+        if not await self.check_conditions(ctx, member, moderator, "flag"):
+            return
+
+        case = await self.db.case.insert_case(
+            case_user_id=member.id,
+            case_moderator_id=ctx.author.id,
+            case_type=CaseType.FLAG,
+            case_reason=flags.reason,
+            guild_id=ctx.guild.id,
+        )
+
+        await self.handle_case_response(ctx, CaseType.FLAG, case.case_number, flags.reason, member, False)
+
+    async def is_flagged(self, guild_id: int, user_id: int) -> bool:
+        """
+        Check if a user is flagged.
+
+        Parameters
+        ----------
+        guild_id : int
+            The ID of the guild to check in.
+        user_id : int
+            The ID of the user to check.
+
+        Returns
+        -------
+        bool
+            True if the user is flagged, False otherwise.
+        """
+
+        flag_cases = await self.case_controller.get_all_cases_by_type(guild_id, CaseType.FLAG)
+        unflag_cases = await self.case_controller.get_all_cases_by_type(guild_id, CaseType.UNFLAG)
+
+        flag_count = sum(case.case_user_id == user_id for case in flag_cases)
+        unflag_count = sum(case.case_user_id == user_id for case in unflag_cases)
+
+        return flag_count > unflag_count
+
+
+async def setup(bot: Tux) -> None:
+    await bot.add_cog(Flag(bot))

--- a/tux/cogs/moderation/flag.py
+++ b/tux/cogs/moderation/flag.py
@@ -10,7 +10,7 @@ from tux.utils.flags import FlagFlags, generate_usage
 from . import ModerationCogBase
 
 
-class Flag(ModerationCogBase):
+class Unflag(ModerationCogBase):
     def __init__(self, bot: Tux) -> None:
         super().__init__(bot)
         self.case_controller = CaseController()
@@ -61,7 +61,7 @@ class Flag(ModerationCogBase):
             guild_id=ctx.guild.id,
         )
 
-        await self.handle_case_response(ctx, CaseType.FLAG, case.case_number, flags.reason, member, False)
+        await self.handle_case_response(ctx, CaseType.FLAG, case.case_number, flags.reason, member, False, True)
 
     async def is_flagged(self, guild_id: int, user_id: int) -> bool:
         """
@@ -90,4 +90,4 @@ class Flag(ModerationCogBase):
 
 
 async def setup(bot: Tux) -> None:
-    await bot.add_cog(Flag(bot))
+    await bot.add_cog(Unflag(bot))

--- a/tux/cogs/moderation/flag.py
+++ b/tux/cogs/moderation/flag.py
@@ -61,7 +61,15 @@ class Unflag(ModerationCogBase):
             guild_id=ctx.guild.id,
         )
 
-        await self.handle_case_response(ctx, CaseType.FLAG, case.case_number, flags.reason, member, False, True)
+        await self.handle_case_response(
+            ctx,
+            CaseType.FLAG,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent=False,
+            silent_action=True,
+        )
 
     async def is_flagged(self, guild_id: int, user_id: int) -> bool:
         """

--- a/tux/cogs/moderation/jail.py
+++ b/tux/cogs/moderation/jail.py
@@ -103,7 +103,15 @@ class Jail(ModerationCogBase):
             return
 
         dm_sent = await self.send_dm(ctx, flags.silent, member, flags.reason, "jailed")
-        await self.handle_case_response(ctx, CaseType.JAIL, case.case_number, flags.reason, member, dm_sent, False)
+        await self.handle_case_response(
+            ctx,
+            CaseType.JAIL,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            silent_action=False,
+        )
 
     def _get_manageable_roles(
         self,

--- a/tux/cogs/moderation/jail.py
+++ b/tux/cogs/moderation/jail.py
@@ -103,7 +103,7 @@ class Jail(ModerationCogBase):
             return
 
         dm_sent = await self.send_dm(ctx, flags.silent, member, flags.reason, "jailed")
-        await self.handle_case_response(ctx, CaseType.JAIL, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(ctx, CaseType.JAIL, case.case_number, flags.reason, member, dm_sent, False)
 
     def _get_manageable_roles(
         self,

--- a/tux/cogs/moderation/kick.py
+++ b/tux/cogs/moderation/kick.py
@@ -73,7 +73,7 @@ class Kick(ModerationCogBase):
             guild_id=ctx.guild.id,
         )
 
-        await self.handle_case_response(ctx, CaseType.KICK, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(ctx, CaseType.KICK, case.case_number, flags.reason, member, dm_sent, False)
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/moderation/kick.py
+++ b/tux/cogs/moderation/kick.py
@@ -73,7 +73,15 @@ class Kick(ModerationCogBase):
             guild_id=ctx.guild.id,
         )
 
-        await self.handle_case_response(ctx, CaseType.KICK, case.case_number, flags.reason, member, dm_sent, False)
+        await self.handle_case_response(
+            ctx,
+            CaseType.KICK,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            silent_action=False,
+        )
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/moderation/snippetban.py
+++ b/tux/cogs/moderation/snippetban.py
@@ -64,7 +64,15 @@ class SnippetBan(ModerationCogBase):
             return
 
         dm_sent = await self.send_dm(ctx, flags.silent, member, flags.reason, "snippet banned")
-        await self.handle_case_response(ctx, CaseType.SNIPPETBAN, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(
+            ctx,
+            CaseType.SNIPPETBAN,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            False,
+        )
 
     async def is_snippetbanned(self, guild_id: int, user_id: int) -> bool:
         """

--- a/tux/cogs/moderation/snippetban.py
+++ b/tux/cogs/moderation/snippetban.py
@@ -71,7 +71,7 @@ class SnippetBan(ModerationCogBase):
             flags.reason,
             member,
             dm_sent,
-            False,
+            silent_action=False,
         )
 
     async def is_snippetbanned(self, guild_id: int, user_id: int) -> bool:

--- a/tux/cogs/moderation/snippetunban.py
+++ b/tux/cogs/moderation/snippetunban.py
@@ -71,7 +71,7 @@ class SnippetUnban(ModerationCogBase):
             flags.reason,
             member,
             dm_sent,
-            False,
+            silent_action=False,
         )
 
     async def is_snippetbanned(self, guild_id: int, user_id: int) -> bool:

--- a/tux/cogs/moderation/snippetunban.py
+++ b/tux/cogs/moderation/snippetunban.py
@@ -64,7 +64,15 @@ class SnippetUnban(ModerationCogBase):
             return
 
         dm_sent = await self.send_dm(ctx, flags.silent, member, flags.reason, "snippet unbanned")
-        await self.handle_case_response(ctx, CaseType.SNIPPETUNBAN, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(
+            ctx,
+            CaseType.SNIPPETUNBAN,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            False,
+        )
 
     async def is_snippetbanned(self, guild_id: int, user_id: int) -> bool:
         """

--- a/tux/cogs/moderation/tempban.py
+++ b/tux/cogs/moderation/tempban.py
@@ -76,7 +76,15 @@ class TempBan(ModerationCogBase):
             case_tempban_expired=False,
         )
 
-        await self.handle_case_response(ctx, CaseType.TEMPBAN, case.case_number, flags.reason, member, dm_sent, False)
+        await self.handle_case_response(
+            ctx,
+            CaseType.TEMPBAN,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            silent_action=False,
+        )
 
     @tasks.loop(hours=1)
     async def tempban_check(self) -> None:

--- a/tux/cogs/moderation/tempban.py
+++ b/tux/cogs/moderation/tempban.py
@@ -76,7 +76,7 @@ class TempBan(ModerationCogBase):
             case_tempban_expired=False,
         )
 
-        await self.handle_case_response(ctx, CaseType.TEMPBAN, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(ctx, CaseType.TEMPBAN, case.case_number, flags.reason, member, dm_sent, False)
 
     @tasks.loop(hours=1)
     async def tempban_check(self) -> None:

--- a/tux/cogs/moderation/timeout.py
+++ b/tux/cogs/moderation/timeout.py
@@ -86,6 +86,7 @@ class Timeout(ModerationCogBase):
             flags.reason,
             member,
             dm_sent,
+            False,
             flags.duration,
         )
 

--- a/tux/cogs/moderation/unban.py
+++ b/tux/cogs/moderation/unban.py
@@ -74,7 +74,15 @@ class Unban(ModerationCogBase):
             case_reason=flags.reason,
         )
 
-        await self.handle_case_response(ctx, CaseType.UNBAN, case.case_number, flags.reason, user, dm_sent=False)
+        await self.handle_case_response(
+            ctx,
+            CaseType.UNBAN,
+            case.case_number,
+            flags.reason,
+            user,
+            dm_sent=False,
+            silent_action=False,
+        )
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/moderation/unflag.py
+++ b/tux/cogs/moderation/unflag.py
@@ -61,7 +61,15 @@ class Flag(ModerationCogBase):
             guild_id=ctx.guild.id,
         )
 
-        await self.handle_case_response(ctx, CaseType.UNFLAG, case.case_number, flags.reason, member, False)
+        await self.handle_case_response(
+            ctx,
+            CaseType.UNFLAG,
+            case.case_number,
+            flags.reason,
+            member,
+            False,
+            silent_action=True,
+        )
 
     async def is_flagged(self, guild_id: int, user_id: int) -> bool:
         """

--- a/tux/cogs/moderation/unflag.py
+++ b/tux/cogs/moderation/unflag.py
@@ -1,0 +1,93 @@
+import discord
+from discord.ext import commands
+
+from prisma.enums import CaseType
+from tux.bot import Tux
+from tux.database.controllers.case import CaseController
+from tux.utils import checks
+from tux.utils.flags import UnFlagFlags, generate_usage
+
+from . import ModerationCogBase
+
+
+class Flag(ModerationCogBase):
+    def __init__(self, bot: Tux) -> None:
+        super().__init__(bot)
+        self.case_controller = CaseController()
+        self.unflag.usage = generate_usage(self.unflag, UnFlagFlags)
+
+    @commands.hybrid_command(
+        name="unflag",
+        aliases=["ufl"],
+    )
+    @commands.guild_only()
+    @checks.has_pl(2)
+    async def unflag(
+        self,
+        ctx: commands.Context[Tux],
+        member: discord.Member,
+        *,
+        flags: UnFlagFlags,
+    ) -> None:
+        """
+        Unflag a member from the server.
+
+        Parameters
+        ----------
+        ctx : commands.Context[Tux]
+            The context in which the command is being invoked.
+        member : discord.Member
+            The member to unflag.
+        flags : UnFlagFlags
+            The flags for the command. (reason: str, silent: bool)
+        """
+
+        assert ctx.guild
+
+        if not await self.is_flagged(ctx.guild.id, member.id):
+            await ctx.send("User is not flagged.", delete_after=30, ephemeral=True)
+            return
+
+        moderator = ctx.author
+
+        if not await self.check_conditions(ctx, member, moderator, "unflag"):
+            return
+
+        case = await self.db.case.insert_case(
+            case_user_id=member.id,
+            case_moderator_id=ctx.author.id,
+            case_type=CaseType.UNFLAG,
+            case_reason=flags.reason,
+            guild_id=ctx.guild.id,
+        )
+
+        await self.handle_case_response(ctx, CaseType.UNFLAG, case.case_number, flags.reason, member, False)
+
+    async def is_flagged(self, guild_id: int, user_id: int) -> bool:
+        """
+        Check if a user is flagged.
+
+        Parameters
+        ----------
+        guild_id : int
+            The ID of the guild to check in.
+        user_id : int
+            The ID of the user to check.
+
+        Returns
+        -------
+        bool
+            True if the user is flagged, False otherwise.
+        """
+
+        flag_cases = await self.case_controller.get_all_cases_by_type(guild_id, CaseType.FLAG)
+        unflag_cases = await self.case_controller.get_all_cases_by_type(guild_id, CaseType.UNFLAG)
+
+        flag_count = sum(case.case_user_id == user_id for case in flag_cases)
+        unflag_count = sum(case.case_user_id == user_id for case in unflag_cases)
+
+        return flag_count > unflag_count
+
+
+async def setup(bot: Tux) -> None:
+    await bot.add_cog(Flag(bot))

--- a/tux/cogs/moderation/unflag.py
+++ b/tux/cogs/moderation/unflag.py
@@ -67,7 +67,7 @@ class Flag(ModerationCogBase):
             case.case_number,
             flags.reason,
             member,
-            False,
+            dm_sent=False,
             silent_action=True,
         )
 

--- a/tux/cogs/moderation/unjail.py
+++ b/tux/cogs/moderation/unjail.py
@@ -88,7 +88,15 @@ class Unjail(ModerationCogBase):
 
         dm_sent = await self.send_dm(ctx, flags.silent, member, flags.reason, "unjailed")
 
-        await self.handle_case_response(ctx, CaseType.UNJAIL, unjail_case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(
+            ctx,
+            CaseType.UNJAIL,
+            unjail_case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            silent_action=False,
+        )
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/moderation/untimeout.py
+++ b/tux/cogs/moderation/untimeout.py
@@ -72,7 +72,15 @@ class Untimeout(ModerationCogBase):
         )
 
         dm_sent = await self.send_dm(ctx, flags.silent, member, flags.reason, "untimed out")
-        await self.handle_case_response(ctx, CaseType.UNTIMEOUT, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(
+            ctx,
+            CaseType.UNTIMEOUT,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            silent_action=False,
+        )
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/moderation/warn.py
+++ b/tux/cogs/moderation/warn.py
@@ -56,7 +56,15 @@ class Warn(ModerationCogBase):
         )
 
         dm_sent = await self.send_dm(ctx, flags.silent, member, flags.reason, "warn")
-        await self.handle_case_response(ctx, CaseType.WARN, case.case_number, flags.reason, member, dm_sent)
+        await self.handle_case_response(
+            ctx,
+            CaseType.WARN,
+            case.case_number,
+            flags.reason,
+            member,
+            dm_sent,
+            silent_action=False,
+        )
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/utils/flags.py
+++ b/tux/utils/flags.py
@@ -309,3 +309,21 @@ class SnippetUnbanFlags(commands.FlagConverter, case_insensitive=True, delimiter
         aliases=["s", "quiet"],
         default=False,
     )
+
+
+class FlagFlags(commands.FlagConverter, case_insensitive=True, delimiter=" ", prefix="-"):
+    reason: str = commands.flag(
+        name="reason",
+        description="Reason for the user flag.",
+        aliases=["r"],
+        default=MISSING,
+    )
+
+
+class UnFlagFlags(commands.FlagConverter, case_insensitive=True, delimiter=" ", prefix="-"):
+    reason: str = commands.flag(
+        name="reason",
+        description="Reason for the user unflag.",
+        aliases=["r"],
+        default=MISSING,
+    )


### PR DESCRIPTION
## Description

Allows moderators to flag users who may be of concern, adding checks for if user is already flagged or not for each command. 
To be improved upon with better features for flagging in the future see #555 for more info.
Emotes for flag and unflag need to be added aswell as they have just been given tempoary emojis.

PR also adds the functionality for cases to not be sent to a logging channel, improves when the handle_case_response is called for maintainability and improving the codebase and updates case embeds to properly convey information about a DM not being sent or a silent action. 

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

tested in tux dev

## Screenshots (if applicable)

n/a

## Additional Information

n/a