### PR TITLE
Feat add permafk command

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,7 +125,7 @@ model AFKModel {
   reason    String
   since     DateTime @default(now())
   guild_id  BigInt
-  perma_afk Boolean  @default(false)
+  perm_afk Boolean  @default(false)
   guild     Guild    @relation(fields: [guild_id], references: [guild_id])
 
   @@unique([member_id, guild_id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,6 +125,7 @@ model AFKModel {
   reason    String
   since     DateTime @default(now())
   guild_id  BigInt
+  perma_afk Boolean  @default(false)
   guild     Guild    @relation(fields: [guild_id], references: [guild_id])
 
   @@unique([member_id, guild_id])

--- a/tux/cogs/utility/afk.py
+++ b/tux/cogs/utility/afk.py
@@ -14,7 +14,7 @@ from tux.utils.constants import CONST
 from tux.utils.flags import generate_usage
 
 
-class AFK(commands.Cog):
+class Afk(commands.Cog):
     def __init__(self, bot: Tux) -> None:
         self.bot = bot
         self.db = AfkController()
@@ -144,4 +144,4 @@ class AFK(commands.Cog):
 
 
 async def setup(bot: Tux):
-    await bot.add_cog(AFK(bot))
+    await bot.add_cog(Afk(bot))

--- a/tux/cogs/utility/afk.py
+++ b/tux/cogs/utility/afk.py
@@ -90,7 +90,7 @@ class Afk(commands.Cog):
 
         if entry.since + timedelta(seconds=10) > datetime.now(ZoneInfo("UTC")):
             return
-        if await self.db.is_perma_afk(message.author.id, guild_id=message.guild.id):
+        if await self.db.is_perm_afk(message.author.id, guild_id=message.guild.id):
             return
         assert isinstance(message.author, discord.Member)
 

--- a/tux/cogs/utility/afk.py
+++ b/tux/cogs/utility/afk.py
@@ -90,7 +90,8 @@ class AFK(commands.Cog):
 
         if entry.since + timedelta(seconds=10) > datetime.now(ZoneInfo("UTC")):
             return
-
+        if await self.db.is_perma_afk(message.author.id, guild_id=message.guild.id):
+            return
         assert isinstance(message.author, discord.Member)
 
         await self.db.remove_afk(message.author.id)

--- a/tux/cogs/utility/permafk.py
+++ b/tux/cogs/utility/permafk.py
@@ -22,6 +22,16 @@ class PERMAFK(commands.Cog):
     @commands.hybrid_command(name="permafk")
     @commands.guild_only()
     async def permafk(self, ctx: commands.Context[Tux], *, reason: str = "No reason.") -> discord.Message:
+        """
+        Set yourself permanently AFK so it doesnt remove your afk status if you send a message.
+
+        Parameters
+        ----------
+        ctx : commands.Context[Tux]
+            The context of the command.
+        reason : str, optional
+            The reason you are AFK.
+        """
         target = ctx.author
         assert ctx.guild
         assert isinstance(target, discord.Member)

--- a/tux/cogs/utility/permafk.py
+++ b/tux/cogs/utility/permafk.py
@@ -10,7 +10,7 @@ from tux.utils.constants import CONST
 from tux.utils.flags import generate_usage
 
 
-class PERMAFK(commands.Cog):
+class PermAfk(commands.Cog):
     def __init__(self, bot: Tux) -> None:
         self.bot = bot
         self.db = AfkController()
@@ -51,7 +51,7 @@ class PERMAFK(commands.Cog):
         with contextlib.suppress(discord.Forbidden):
             await target.edit(nick=new_name)
         return await ctx.send(
-            content="\N{SLEEPING SYMBOL} || You are now permanently afk! To remove afk run this command again."
+            content="\N{SLEEPING SYMBOL} || You are now permanently afk! To remove afk run this command again. "
             + f"Reason: `{shortened_reason}`",
             allowed_mentions=discord.AllowedMentions(
                 users=False,
@@ -62,4 +62,4 @@ class PERMAFK(commands.Cog):
 
 
 async def setup(bot: Tux):
-    await bot.add_cog(PERMAFK(bot))
+    await bot.add_cog(PermAfk(bot))

--- a/tux/cogs/utility/permafk.py
+++ b/tux/cogs/utility/permafk.py
@@ -1,0 +1,55 @@
+import contextlib
+import textwrap
+
+import discord
+from discord.ext import commands
+
+from tux.bot import Tux
+from tux.database.controllers import AfkController
+from tux.utils.constants import CONST
+from tux.utils.flags import generate_usage
+
+
+class PERMAFK(commands.Cog):
+    def __init__(self, bot: Tux) -> None:
+        self.bot = bot
+        self.db = AfkController()
+        self.permafk.usage = generate_usage(self.permafk)
+
+    async def remove_afk(self, target: int) -> None:
+        await self.db.remove_afk(target)
+
+    @commands.hybrid_command(name="permafk")
+    @commands.guild_only()
+    async def permafk(self, ctx: commands.Context[Tux], *, reason: str = "No reason.") -> discord.Message:
+        target = ctx.author
+        assert ctx.guild
+        assert isinstance(target, discord.Member)
+        if await self.db.is_afk(target.id, guild_id=ctx.guild.id):
+            await self.remove_afk(target.id)
+            return await ctx.send("Welcome back!")
+
+        if len(target.display_name) >= CONST.NICKNAME_MAX_LENGTH - 6:
+            truncated_name = f"{target.display_name[: CONST.NICKNAME_MAX_LENGTH - 9]}..."
+            new_name = f"[AFK] {truncated_name}"
+        else:
+            new_name = f"[AFK] {target.display_name}"
+
+        shortened_reason = textwrap.shorten(reason, width=100, placeholder="...")
+        await self.db.insert_afk(target.id, target.display_name, shortened_reason, ctx.guild.id, True)
+
+        with contextlib.suppress(discord.Forbidden):
+            await target.edit(nick=new_name)
+        return await ctx.send(
+            content="\N{SLEEPING SYMBOL} || You are now permanently afk! To remove afk run this command again."
+            + f"Reason: `{shortened_reason}`",
+            allowed_mentions=discord.AllowedMentions(
+                users=False,
+                everyone=False,
+                roles=False,
+            ),
+        )
+
+
+async def setup(bot: Tux):
+    await bot.add_cog(PERMAFK(bot))

--- a/tux/cogs/utility/permafk.py
+++ b/tux/cogs/utility/permafk.py
@@ -23,7 +23,7 @@ class PermAfk(commands.Cog):
     @commands.guild_only()
     async def permafk(self, ctx: commands.Context[Tux], *, reason: str = "No reason.") -> discord.Message:
         """
-        Set yourself permanently AFK so it doesnt remove your afk status if you send a message.
+        Set yourself permanently AFK until you rerun the command.
 
         Parameters
         ----------
@@ -32,16 +32,21 @@ class PermAfk(commands.Cog):
         reason : str, optional
             The reason you are AFK.
         """
+
         target = ctx.author
+
         assert ctx.guild
         assert isinstance(target, discord.Member)
+
         if await self.db.is_afk(target.id, guild_id=ctx.guild.id):
             await self.remove_afk(target.id)
+
             return await ctx.send("Welcome back!")
 
         if len(target.display_name) >= CONST.NICKNAME_MAX_LENGTH - 6:
             truncated_name = f"{target.display_name[: CONST.NICKNAME_MAX_LENGTH - 9]}..."
             new_name = f"[AFK] {truncated_name}"
+
         else:
             new_name = f"[AFK] {target.display_name}"
 
@@ -50,6 +55,7 @@ class PermAfk(commands.Cog):
 
         with contextlib.suppress(discord.Forbidden):
             await target.edit(nick=new_name)
+
         return await ctx.send(
             content="\N{SLEEPING SYMBOL} || You are now permanently afk! To remove afk run this command again. "
             + f"Reason: `{shortened_reason}`",

--- a/tux/database/controllers/__init__.py
+++ b/tux/database/controllers/__init__.py
@@ -17,5 +17,6 @@ class DatabaseController:
         self.guild = GuildController()
         self.guild_config = GuildConfigController()
         self.afk = AfkController()
+        self.permafk = AfkController()
         self.starboard = StarboardController()
         self.starboard_message = StarboardMessageController()

--- a/tux/database/controllers/__init__.py
+++ b/tux/database/controllers/__init__.py
@@ -17,6 +17,5 @@ class DatabaseController:
         self.guild = GuildController()
         self.guild_config = GuildConfigController()
         self.afk = AfkController()
-        self.permafk = AfkController()
         self.starboard = StarboardController()
         self.starboard_message = StarboardMessageController()

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -22,11 +22,11 @@ class AfkController:
         entry = await self.get_afk_member(member_id, guild_id=guild_id)
         return entry is not None
 
-    async def is_perma_afk(self, member_id: int, *, guild_id: int) -> bool:
-        is_user_perma_afk = await self.table.find_first(
+    async def is_perm_afk(self, member_id: int, *, guild_id: int) -> bool:
+        is_user_perm_afk = await self.table.find_first(
             where={"member_id": member_id, "guild_id": guild_id, "perma_afk": True},
         )
-        return is_user_perma_afk is not None
+        return is_user_perm_afk is not None
 
     async def insert_afk(
         self,
@@ -34,7 +34,7 @@ class AfkController:
         nickname: str,
         reason: str,
         guild_id: int,
-        perma_afk: bool = False,
+        perm_afk: bool = False,
     ) -> AFKModel:
         await self.ensure_guild_exists(guild_id)
 
@@ -44,7 +44,7 @@ class AfkController:
                 "nickname": nickname,
                 "reason": reason,
                 "guild_id": guild_id,
-                "perma_afk": perma_afk,
+                "perma_afk": perm_afk,
             },
         )
 

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -24,7 +24,7 @@ class AfkController:
 
     async def is_perm_afk(self, member_id: int, *, guild_id: int) -> bool:
         is_user_perm_afk = await self.table.find_first(
-            where={"member_id": member_id, "guild_id": guild_id, "perma_afk": True},
+            where={"member_id": member_id, "guild_id": guild_id, "perm_afk": True},
         )
         return is_user_perm_afk is not None
 

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -26,9 +26,7 @@ class AfkController:
         is_user_perma_afk = await self.table.find_first(
             where={"member_id": member_id, "guild_id": guild_id, "perma_afk": True},
         )
-        if is_user_perma_afk is None:
-            return is_user_perma_afk is not None
-        return True
+        return is_user_perma_afk is not None
 
     async def insert_afk(
         self,

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -44,7 +44,7 @@ class AfkController:
                 "nickname": nickname,
                 "reason": reason,
                 "guild_id": guild_id,
-                "perma_afk": perm_afk,
+                "perm_afk": perm_afk,
             },
         )
 

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -22,7 +22,22 @@ class AfkController:
         entry = await self.get_afk_member(member_id, guild_id=guild_id)
         return entry is not None
 
-    async def insert_afk(self, member_id: int, nickname: str, reason: str, guild_id: int) -> AFKModel:
+    async def is_perma_afk(self, member_id: int, *, guild_id: int) -> bool:
+        is_user_perma_afk = await self.table.find_first(
+            where={"member_id": member_id, "guild_id": guild_id, "perma_afk": True},
+        )
+        if is_user_perma_afk is None:
+            return is_user_perma_afk is not None
+        return True
+
+    async def insert_afk(
+        self,
+        member_id: int,
+        nickname: str,
+        reason: str,
+        guild_id: int,
+        perma_afk: bool = False,
+    ) -> AFKModel:
         await self.ensure_guild_exists(guild_id)
 
         return await self.table.create(
@@ -31,6 +46,7 @@ class AfkController:
                 "nickname": nickname,
                 "reason": reason,
                 "guild_id": guild_id,
+                "perma_afk": perma_afk,
             },
         )
 


### PR DESCRIPTION
## Description

This pr contains the feature that allows you to set yourself afk without it going away when you send a message as described in issue #516 the command is permafk and you can disable afk by running the command again

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x ] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

tested in my own test server both normal afk command and the permafk command both seem to work fine

## Summary by Sourcery

Add a new 'permafk' command to allow users to set themselves as permanently AFK, preventing the AFK status from being removed when they send a message. Update the database controller to support this feature and enhance the AFK functionality.

New Features:
- Introduce a new 'permafk' command that allows users to set themselves as permanently AFK, which does not reset when they send a message.

Enhancements:
- Add a new method 'is_perma_afk' to check if a user is permanently AFK in the database.

Documentation:
- Update documentation to include information about the new 'permafk' command.