### PR TITLE
[FIX] fixed bug per issue 678. This allows the bot to retrieve the co…

### DIFF
--- a/tux/cogs/moderation/cases.py
+++ b/tux/cogs/moderation/cases.py
@@ -257,7 +257,7 @@ class Cases(ModerationCogBase):
         """
 
         if case is not None:
-            moderator = ctx.author
+            moderator = await commands.MemberConverter().convert(ctx, str(case.case_moderator_id))
 
             if isinstance(moderator, discord.Member):
                 fields = self._create_case_fields(moderator, user, reason)

--- a/tux/cogs/moderation/cases.py
+++ b/tux/cogs/moderation/cases.py
@@ -257,16 +257,12 @@ class Cases(ModerationCogBase):
         """
 
         if case is not None:
-            moderator = await commands.MemberConverter().convert(ctx, str(case.case_moderator_id))
+            try:
+                moderator = await commands.MemberConverter().convert(ctx, str(case.case_moderator_id))
+            except commands.errors.MemberNotFound:
+                moderator = await commands.UserConverter().convert(ctx, str(case.case_moderator_id))
 
-            if isinstance(moderator, discord.Member):
-                fields = self._create_case_fields(moderator, user, reason)
-            else:
-                fields = self._create_case_fields(
-                    await commands.MemberConverter().convert(ctx, str(case.case_moderator_id)),
-                    user,
-                    reason,
-                )
+            fields = self._create_case_fields(moderator, user, reason)
 
             embed = self.create_embed(
                 ctx,
@@ -324,7 +320,7 @@ class Cases(ModerationCogBase):
 
     @staticmethod
     def _create_case_fields(
-        moderator: discord.Member,
+        moderator: discord.Member | discord.User,
         user: discord.Member | discord.User,
         reason: str,
     ) -> list[tuple[str, str, bool]]:


### PR DESCRIPTION
…rrect moderator from a single case view instead of whoever runs the command returning as the moderator.

## Description

Fixes #678 
Allows us to view the correct moderator within the single case view now. For example when we run /case view case:5 it would show the correct moderator that took that case instead of the moderator that ran the command.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [ X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

I have tested my code via running the dev tux instance on the development server and testing that the moderator returns correctly.

## Screenshots (if applicable)

N/A

## Additional Information

N/A

## Summary by Sourcery

Bug Fixes:
- Fixed a bug where running `/case view` would show the user who ran the command as the moderator instead of the moderator who originally took the case.