### PR TITLE
Capatalise all queries to wiki

### DIFF
--- a/tux/cogs/utility/wiki.py
+++ b/tux/cogs/utility/wiki.py
@@ -31,6 +31,8 @@ class Wiki(commands.Cog):
             The title and URL of the first search result.
         """
 
+        search_term = search_term.capitalize()
+
         params: dict[str, str] = {
             "action": "opensearch",
             "format": "json",
@@ -65,6 +67,8 @@ class Wiki(commands.Cog):
         tuple[str, str]
             The title and URL of the first search result.
         """
+
+        search_term = search_term.capitalize()
 
         params: dict[str, str] = {
             "action": "opensearch",


### PR DESCRIPTION
## Description

Takes any input to the command and capatalises it as mediawiki only allows pages being capatalised.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Yes, in #sandbox in atl.dev

## Screenshots (if applicable)

n/a

## Additional Information

n/a