### PR TITLE
Refactor Dockerfile to use multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
+.devcontainer/
+.env
+.git/
+.github/
 .venv/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,99 @@
-FROM python:3.12-slim AS builder
+# Base stage:
+# - Pin the Python base image for all stages
+# - Install only the common runtime dependencies
+#   - git
+#   - tealdeer
+FROM python:3.12-slim AS base
 
-# Set the working directory
-WORKDIR /app
-
-# Install dependencies for building and runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential \
-    curl \
-    git \
-    libcairo2 \
-    libffi-dev \
-    libgdk-pixbuf2.0-0 \
-    libpango1.0-0 \
-    libpangocairo-1.0-0 \
-    shared-mime-info && \
+        git \
+        tealdeer && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    tldr -u
+
+# Tweak Python to run better in Docker
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=on
+
+
+# Build stage:
+# - Install build tools (for packages with native dependencies)
+# - Install poetry (for managing app's dependencies)
+# - Install app's main dependencies
+# - Install the application itself
+# - Generate Prisma client
+FROM base AS build
+
+# TODO: Are these needed?
+# - curl
+# - libgdk-pixbuf2.0-0
+# - libpango1.0-0
+# - libpangocairo-1.0-0
+# - shared-mime-info
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        libcairo2 \
+        libffi-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Rust and Cargo
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-    echo 'export PATH="/root/.cargo/bin:$PATH"' >> /etc/profile.d/cargo.sh
+ENV POETRY_VERSION=2.0.1 \
+    POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
 
-# Install tealdeer and update tldr cache
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN cargo install tealdeer && tldr -u
+RUN --mount=type=cache,target=/root/.cache pip install poetry==$POETRY_VERSION
+
+WORKDIR /app
+
+# Copy only the metadata files to increase build cache hit rate
+COPY pyproject.toml poetry.lock ./
+RUN --mount=type=cache,target=$POETRY_CACHE_DIR \
+    poetry install --only main --no-root --no-directory
+
+# Now install the application itself
+COPY . .
+RUN --mount=type=cache,target=$POETRY_CACHE_DIR \
+    --mount=type=cache,target=/root/.cache \
+    poetry install --only main && \
+    poetry run prisma py fetch && \
+    poetry run prisma generate
 
 
-# Copy Poetry files and install dependencies
-COPY . /app
-RUN pip install --no-cache-dir poetry && \
-    poetry config virtualenvs.create false && \
-    poetry install --no-interaction --no-ansi
+# Dev stage (used by docker-compose):
+# - Install extra tools for development (pre-commit, ruff, pyright, types, etc.)
+# - Re-generate Prisma client on every run
+FROM build AS dev
 
-# Set PYTHONPATH environment variable to /app
-ENV PYTHONPATH=/app
+WORKDIR /app
 
-# Command to run the application
-CMD ["sh", "-c", "ls && poetry run prisma py fetch && poetry run prisma generate && poetry run python tux/main.py"]
+RUN --mount=type=cache,target=$POETRY_CACHE_DIR \
+    poetry install --only dev --no-root --no-directory
+
+CMD ["sh", "-c", "ls && poetry run prisma generate && exec poetry run python tux/main.py"]
+
+
+# Production stage:
+# - Start with the base with the runtime dependencies already installed
+# - Run the app as a nonroot user (least privileges principle)
+# - Use the packaged self-sufficient application bundle
+FROM base AS production
+
+RUN adduser nonroot
+USER nonroot
+
+WORKDIR /app
+
+ENV VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
+
+COPY --from=build --chown=nonroot:nonroot /app ./
+
+ENTRYPOINT ["python"]
+CMD ["-m", "tux.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   tux:
-    build: .
+    build:
+      context: .
+      target: dev
     image: allthingslinux/tux:latest
     container_name: tux
     restart: always

--- a/poetry.lock
+++ b/poetry.lock
@@ -406,7 +406,7 @@ version = "3.4.0"
 description = "Validate configuration and produce human readable error messages."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
@@ -674,7 +674,7 @@ version = "0.3.9"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87"},
     {file = "distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"},
@@ -698,7 +698,7 @@ version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -941,7 +941,7 @@ version = "2.6.6"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "identify-2.6.6-py2.py3-none-any.whl", hash = "sha256:cbd1810bce79f8b671ecb20f53ee0ae8e86ae84b557de31d89709dc2a48ba881"},
     {file = "identify-2.6.6.tar.gz", hash = "sha256:7bec12768ed44ea4761efb47806f0a41f86e7c0a5fdf5950d4648c90eca7e251"},
@@ -1342,7 +1342,7 @@ version = "1.9.1"
 description = "Node.js virtual environment builder"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
@@ -1492,7 +1492,7 @@ version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "docs"]
+groups = ["dev", "docs"]
 files = [
     {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
     {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
@@ -1509,7 +1509,7 @@ version = "4.1.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "pre_commit-4.1.0-py2.py3-none-any.whl", hash = "sha256:d29e7cb346295bcc1cc75fc3e92e343495e3ea0196c9ec6ba53f49f10ab6ae7b"},
     {file = "pre_commit-4.1.0.tar.gz", hash = "sha256:ae3f018575a588e30dfddfab9a05448bfbd6b73d78709617b5a2b853549716d4"},
@@ -1917,7 +1917,7 @@ version = "1.1.392.post0"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "pyright-1.1.392.post0-py3-none-any.whl", hash = "sha256:252f84458a46fa2f0fd4e2f91fc74f50b9ca52c757062e93f6c250c0d8329eb2"},
     {file = "pyright-1.1.392.post0.tar.gz", hash = "sha256:3b7f88de74a28dcfa90c7d90c782b6569a48c2be5f9d4add38472bdaac247ebd"},
@@ -1980,7 +1980,7 @@ version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
     {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
@@ -2214,7 +2214,7 @@ version = "0.9.2"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "ruff-0.9.2-py3-none-linux_armv6l.whl", hash = "sha256:80605a039ba1454d002b32139e4970becf84b5fee3a3c3bf1c2af6f61a784347"},
     {file = "ruff-0.9.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b9aab82bb20afd5f596527045c01e6ae25a718ff1784cb92947bff1f83068b00"},
@@ -2370,7 +2370,7 @@ version = "24.1.0.20241221"
 description = "Typing stubs for aiofiles"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "types_aiofiles-24.1.0.20241221-py3-none-any.whl", hash = "sha256:11d4e102af0627c02e8c1d17736caa3c39de1058bea37e2f4de6ef11a5b652ab"},
     {file = "types_aiofiles-24.1.0.20241221.tar.gz", hash = "sha256:c40f6c290b0af9e902f7f3fa91213cf5bb67f37086fb21dc0ff458253586ad55"},
@@ -2382,7 +2382,7 @@ version = "1.2.0.20240420"
 description = "Typing stubs for dateparser"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "types-dateparser-1.2.0.20240420.tar.gz", hash = "sha256:8f813ddf5ef41b32cabe6167138ae833ada10c22811e42220a1e38a0be7adbdc"},
     {file = "types_dateparser-1.2.0.20240420-py3-none-any.whl", hash = "sha256:bf3695ddfbadfdfc875064895a51d926fd80b04da1a44364c6c1a9703db7b194"},
@@ -2394,7 +2394,7 @@ version = "6.1.0.20241221"
 description = "Typing stubs for psutil"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "types_psutil-6.1.0.20241221-py3-none-any.whl", hash = "sha256:8498dbe13285a9ba7d4b2fa934c569cc380efc74e3dacdb34ae16d2cdf389ec3"},
     {file = "types_psutil-6.1.0.20241221.tar.gz", hash = "sha256:600f5a36bd5e0eb8887f0e3f3ff2cf154d90690ad8123c8a707bba4ab94d3185"},
@@ -2406,7 +2406,7 @@ version = "2024.2.0.20241221"
 description = "Typing stubs for pytz"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "types_pytz-2024.2.0.20241221-py3-none-any.whl", hash = "sha256:8fc03195329c43637ed4f593663df721fef919b60a969066e22606edf0b53ad5"},
     {file = "types_pytz-2024.2.0.20241221.tar.gz", hash = "sha256:06d7cde9613e9f7504766a0554a270c369434b50e00975b3a4a0f6eed0f2c1a9"},
@@ -2418,7 +2418,7 @@ version = "6.0.12.20241230"
 description = "Typing stubs for PyYAML"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"},
     {file = "types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c"},
@@ -2430,7 +2430,7 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
@@ -2491,7 +2491,7 @@ version = "20.29.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779"},
     {file = "virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35"},
@@ -2677,4 +2677,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "c32a42fe4766fb7bdc493412be532b98898a6ffc6383e5207480bf6db6656e09"
+content-hash = "57ca5388d734dd1c13a1f8fc38fc869cf9621f217753588e7d8dce9b45fadc65"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,30 +20,32 @@ dependencies = [
     "jishaku>=2.5.2",
     "loguru>=0.7.2",
     "pillow>=10.3.0,<11.0.0",
-    "pre-commit>=4.0.0",
     "prisma>=0.15.0",
     "psutil>=6.0.0",
     "pydantic>=2.8.2",
     "pynacl>=1.5.0",
-    "pyright>=1.1.358",
     "python-dotenv>=1.0.1",
     "pytz>=2024.1",
     "pyyaml>=6.0.2",
     "reactionmenu>=3.1.7",
     "rsa>=4.9",
-    "ruff>=0.8.0",
     "sentry-sdk[httpx,loguru]>=2.7.0",
-    "types-aiofiles>=24.1.0.20240626",
-    "types-dateparser>=1.2.0.20240420",
-    "types-psutil>=6.0.0.20240621",
-    "types-pytz>=2024.2.0.20240913",
-    "types-pyyaml>=6.0.12.20240808",
     "typing-extensions>=4.12.2"
 ]
 
 [build-system]
 requires = ["poetry-core>=2.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.group.dev.dependencies]
+pre-commit = ">=4.0.0"
+pyright = ">=1.1.358"
+ruff = ">=0.8.0"
+types-aiofiles = ">=24.1.0.20240626"
+types-dateparser = ">=1.2.0.20240420"
+types-psutil = ">=6.0.0.20240621"
+types-pytz = ">=2024.2.0.20240913"
+types-pyyaml = ">=6.0.12.20240808"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs-material = "^9.5.30"


### PR DESCRIPTION
- Speed up builds by reusing different types of cache
- Get rid of a dependency on the Rust toolchain
- Reduce the image size x6.5 (from 2.2GB to ~340MB)
- Reduce the number of vulnerabilities x5.5:

Original: 791 (UNKNOWN: 0, LOW: 282, MEDIUM: 425, HIGH: 83, CRITICAL: 1)
Improved: 122 (UNKNOWN: 0, LOW: 89, MEDIUM: 22, HIGH: 10, CRITICAL: 1)

## Summary by Sourcery

Refactor the Dockerfile to use a multi-stage build, reducing the image size and the number of vulnerabilities.

Enhancements:
- Reduce the Docker image size by a factor of 6.5, from 2.2GB to ~340MB.
- Reduce the number of vulnerabilities by a factor of 5.5.
- Remove the dependency on the Rust toolchain during the build process.

Build:
- Use a multi-stage build in the Dockerfile.