### PR TITLE
Improve settings system and make some naming less tux specific

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -1,24 +1,66 @@
-# config/settings.yml
+# This is a example configuration file for Tux
+# Change the values to your liking and rename the file to settings.yml
 
-DEFAULT_PREFIX:
-  PROD: "$"
-  DEV: "~"
+BOT_INFO:
+  PROD_PREFIX: "$"
+  DEV_PREFIX: "~" # You can enable dev mode in .env
+  BOT_NAME: "Tux" # This may not apply everywhere, WIP (Best to keep it as Tux for now). Help command will be changed to be less Tux-specific if you change this.
+  BOT_VERSION: "git" # vX.Y.Z or git
+  # Available substitutions:
+  # {member_count} - total member count of all guilds
+  # {guild_count} - total guild count
+  # {bot_name} - bot name
+  # {bot_version} - bot version
+  # {prefix} - bot prefix
+  ACTIVITIES: |
+    [
+      {"type": "watching", "name": "{member_count} members"},
+      {"type": "listening", "name": "{guild_count} guilds"},
+      {"type": "playing", "name": "{bot_name} {bot_version}"},
+      {"type": "watching", "name": "All Things Linux"},
+      {"type": "playing", "name": "with fire"},
+      {"type": "watching", "name": "linux tech tips"},
+      {"type": "listening", "name": "mpd"},
+      {"type": "watching", "name": "a vast field of grain"},
+      {"type": "playing", "name": "i am calling about your car's extended warranty"},
+      {"type": "playing", "name": "SuperTuxKart"},
+      {"type": "playing", "name": "SuperTux 2"},
+      {"type": "watching", "name": "Gentoo compile..."},
+      {"type": "watching", "name": "Brodie Robertson"},
+      {"type": "listening", "name": "Terry Davis on YouTube"},
+      {"type": "playing", "name": "with Puffy"},
+      {"type": "watching", "name": "the stars"},
+      {"type": "watching", "name": "VLC"},
+      {"type": "streaming", "name": "SuperTuxKart", "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}
+    ]
+
 
 USER_IDS:
-  SYSADMINS:
+  SYSADMINS: # WARNING! This grants dangerous permissions such as eval and jsk which can be used to execute arbitrary code.
     - 123456789012345679
     - 123456789012345679
-  BOT_OWNER: 123456789012345679
+  BOT_OWNER: 123456789012345679 # This is the user who has the highest level of control over the bot. Only one user can be the bot owner.
 
+# This adds a temporary voice channel feature to the bot, you can join the channel to create a channel called /tmp/<username> and move to it.
+# Channels are deleted when the last person leaves them.
+# Set this to the category ID where you want the temporary voice channels to be created.
+# Temporary channels will be put at the bottom of the category.
 TEMPVC_CATEGORY_ID: 123456789012345679
+# Set this to the channel ID where you want the temporary voice channels to be created.
 TEMPVC_CHANNEL_ID: 123456789012345679
 
 
+SNIPPETS:
+  LIMIT_TO_ROLE_IDS: false # Only allow users with the specified role IDs to use the snippet command
+  ACCESS_ROLE_IDS:
+    - 123456789012345679
+    - 123456789012345679
+
 XP:
-  XP_BLACKLIST_CHANNELS:
+  XP_BLACKLIST_CHANNELS: # Channels where XP will not be counted
     - 123456789012345679
     - 123456789012345679
-  XP_ROLES:
+  XP_ROLES: # Roles that will be given to users when they reach a certain level
     - level: 5
       role_id: 123456789012345679
     - level: 10
@@ -30,18 +72,17 @@ XP:
     - level: 25
       role_id: 123456789012345679
 
-  XP_MULTIPLIERS:
+  XP_MULTIPLIERS: # Multipliers for certain roles
     - role_id: 123456789012345679
       multiplier: 1.5
 
-  XP_COOLDOWN: 1 # In seconds
+  XP_COOLDOWN: 1 # Delay in seconds between XP messages
 
-  LEVELS_EXPONENT: 1
-  SHOW_XP_PROGRESS: false
-  # if true, XP will still be counted, but not shown beyond the cap in the level command
-  ENABLE_XP_CAP: false
+  LEVELS_EXPONENT: 1 # Exponent for the level formula
+  SHOW_XP_PROGRESS: false # Shows required XP for the next level in the level command
+  ENABLE_XP_CAP: false # if true, XP will still be counted, but not shown beyond the cap in the level command
 
-GIF_LIMITER:
+GIF_LIMITER: # Limits the amount of gifs a user can send in a channel
   RECENT_GIF_AGE: 60
 
   GIF_LIMIT_EXCLUDE:

--- a/tux/cogs/guild/setup.py
+++ b/tux/cogs/guild/setup.py
@@ -13,7 +13,7 @@ class Setup(commands.Cog):
         self.db = DatabaseController()
         self.config = DatabaseController().guild_config
 
-    setup = app_commands.Group(name="setup", description="Set up Tux for your server.")
+    setup = app_commands.Group(name="setup", description="Set this bot up for your server.")
 
     @setup.command(name="jail")
     @commands.guild_only()

--- a/tux/cogs/utility/snippets.py
+++ b/tux/cogs/utility/snippets.py
@@ -14,6 +14,7 @@ from tux.bot import Tux
 from tux.database.controllers import CaseController, DatabaseController
 from tux.ui.embeds import EmbedCreator, EmbedType
 from tux.utils import checks
+from tux.utils.config import Config
 from tux.utils.flags import generate_usage
 
 
@@ -349,17 +350,17 @@ class Snippets(commands.Cog):
             The content of the snippet.
         """
 
-        # TODO: Remove hardcoded role ids
-
-        # If user does not have any of the access level roles, return
-        access_level_role_ids = [1290368764470231092, 1290368813627346995]
-
         assert ctx.guild
 
-        if isinstance(ctx.author, discord.Member) and all(
-            role.id not in access_level_role_ids for role in ctx.author.roles
+        if (
+            Config.LIMIT_TO_ROLE_IDS
+            and isinstance(ctx.author, discord.Member)
+            and not any(role.id in Config.ACCESS_ROLE_IDS for role in ctx.author.roles)
         ):
-            await ctx.send("You do not have the permission to use this command.")
+            await ctx.send(
+                f"You do not have a role that allows you to create snippets. Accepted roles: {format(', '.join([f'<@&{role_id}>' for role_id in Config.ACCESS_ROLE_IDS]))}",
+                allowed_mentions=AllowedMentions.none(),
+            )
             return
 
         if await self.is_snippetbanned(ctx.guild.id, ctx.author.id):

--- a/tux/handlers/activity.py
+++ b/tux/handlers/activity.py
@@ -1,10 +1,22 @@
 import asyncio
+import json
 from typing import NoReturn
 
 import discord
 from discord.ext import commands
+from loguru import logger
 
 from tux.bot import Tux
+from tux.utils.config import Config
+
+# Map the string type to the discord.ActivityType enum.
+ACTIVITY_TYPE_MAP = {
+    "playing": discord.ActivityType.playing,
+    "streaming": discord.ActivityType.streaming,
+    "listening": discord.ActivityType.listening,
+    "watching": discord.ActivityType.watching,
+    # Add other types if needed
+}
 
 
 class ActivityHandler(commands.Cog):
@@ -15,52 +27,78 @@ class ActivityHandler(commands.Cog):
 
     @staticmethod
     def build_activity_list() -> list[discord.Activity | discord.Streaming]:
-        activity_data = [
-            {"type": discord.ActivityType.watching, "name": "{member_count} members"},
-            {"type": discord.ActivityType.watching, "name": "All Things Linux"},
-            {"type": discord.ActivityType.playing, "name": "with fire"},
-            {"type": discord.ActivityType.watching, "name": "linux tech tips"},
-            {"type": discord.ActivityType.listening, "name": "mpd"},
-            {"type": discord.ActivityType.watching, "name": "a vast field of grain"},
-            {"type": discord.ActivityType.playing, "name": "i am calling about your car's extended warranty"},
-            {"type": discord.ActivityType.playing, "name": "SuperTuxKart"},
-            {"type": discord.ActivityType.playing, "name": "SuperTux 2"},
-            {"type": discord.ActivityType.watching, "name": "Gentoo compile..."},
-            {"type": discord.ActivityType.watching, "name": "Brodie Robertson"},
-            {"type": discord.ActivityType.listening, "name": "Terry Davis on YouTube"},
-            {"type": discord.ActivityType.playing, "name": "with Puffy"},
-            {"type": discord.ActivityType.watching, "name": "the stars"},
-            {"type": discord.ActivityType.watching, "name": "VLC"},
-            {"type": "streaming", "name": "SuperTuxKart", "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"},
-        ]
+        """Parses Config.ACTIVITIES as JSON and returns a list of activity objects."""
+        # Debug output to see the config value
+        logger.info(f"Config.ACTIVITIES: {Config.ACTIVITIES!r}")
+
+        if not Config.ACTIVITIES or not Config.ACTIVITIES.strip():
+            logger.warning("Config.ACTIVITIES is empty or None. Returning an empty list.")
+            return []
+
+        try:
+            activity_data = json.loads(Config.ACTIVITIES)  # Safely parse JSON
+        except json.JSONDecodeError:
+            logger.error(f"Failed to parse ACTIVITIES JSON: {Config.ACTIVITIES!r}")
+            raise  # Re-raise after logging
 
         activities: list[discord.Activity | discord.Streaming] = []
 
         for data in activity_data:
-            if data["type"] == "streaming":
+            activity_type_str = data.get("type", "").lower()
+            if activity_type_str == "streaming":
                 activities.append(discord.Streaming(name=str(data["name"]), url=str(data["url"])))
             else:
-                activities.append(discord.Activity(type=data["type"], name=data["name"]))
+                # Map the string to the discord.ActivityType enum; default to "playing" if not found.
+                activity_type = ACTIVITY_TYPE_MAP.get(activity_type_str, discord.ActivityType.playing)
+                activities.append(discord.Activity(type=activity_type, name=data["name"]))
+
         return activities
 
     def _get_member_count(self) -> int:
+        """Returns the total member count of all guilds the bot is in."""
         return sum(guild.member_count for guild in self.bot.guilds if guild.member_count is not None)
 
+    async def handle_substitution(
+        self,
+        activity: discord.Activity | discord.Streaming,
+    ) -> discord.Activity | discord.Streaming:
+        """Replaces multiple placeholders in the activity name."""
+        # Available substitutions:
+        # {member_count} - total member count of all guilds
+        # {guild_count} - total guild count
+        # {bot_name} - bot name
+        # {bot_version} - bot version
+        # {prefix} - bot prefix
+
+        if activity.name and "{member_count}" in activity.name:
+            activity.name = activity.name.replace("{member_count}", str(self._get_member_count()))
+        if activity.name and "{guild_count}" in activity.name:
+            activity.name = activity.name.replace("{guild_count}", str(len(self.bot.guilds)))
+        if activity.name and "{bot_name}" in activity.name:
+            activity.name = activity.name.replace("{bot_name}", Config.BOT_NAME)
+        if activity.name and "{bot_version}" in activity.name:
+            activity.name = activity.name.replace("{bot_version}", Config.BOT_VERSION)
+        if activity.name and "{prefix}" in activity.name:
+            activity.name = activity.name.replace("{prefix}", Config.DEFAULT_PREFIX)
+
+        return activity
+
     async def run(self) -> NoReturn:
+        """Loops through activities and updates bot presence periodically."""
         while True:
             for activity in self.activities:
-                if activity.name and "{member_count}" in activity.name:
-                    activity.name = activity.name.replace("{member_count}", str(self._get_member_count()))
-
-                await self.bot.change_presence(activity=activity)
+                substituted_activity = await self.handle_substitution(activity)
+                await self.bot.change_presence(activity=substituted_activity)
                 await asyncio.sleep(self.delay)
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
+        """Runs the activity loop when the bot is ready."""
         await asyncio.sleep(5)
         activity_task = asyncio.create_task(self.run())
         await asyncio.gather(activity_task)
 
 
 async def setup(bot: Tux) -> None:
+    """Adds the cog to the bot."""
     await bot.add_cog(ActivityHandler(bot))

--- a/tux/help.py
+++ b/tux/help.py
@@ -220,10 +220,18 @@ class TuxHelp(commands.HelpCommand):
             show_page_director=False,
         )
 
-        embed = self._embed_base(
-            "Hello! Welcome to the help command.",
-            "Tux is an all-in-one bot for the All Things Linux Discord server. The bot is written in Python 3.12 using discord.py, and we are actively seeking contributors!",
-        )
+        # TODO: Make help command more customizable
+        if CONFIG.BOT_NAME != "Tux":
+            logger.info("Bot name is not Tux, using different help message.")
+            embed = self._embed_base(
+                "Hello! Welcome to the help command.",
+                f"{CONFIG.BOT_NAME} is an self hosted instance of Tux. The bot is written in Python using discord.py.\n\nIf you enjoy using {CONFIG.BOT_NAME}, consider contributing to the original project.",
+            )
+        else:
+            embed = self._embed_base(
+                "Hello! Welcome to the help command.",
+                "Tux is an all-in-one bot by the All Things Linux Discord server. The bot is written in Python using discord.py, and we are actively seeking contributors.",
+            )
 
         await self._add_bot_help_fields(embed)
         menu.add_page(embed)

--- a/tux/utils/config.py
+++ b/tux/utils/config.py
@@ -21,14 +21,19 @@ class Config:
 
     # Production env
     PROD_TOKEN: Final[str] = os.getenv("PROD_TOKEN", "")
-    DEFAULT_PROD_PREFIX: Final[str] = config["DEFAULT_PREFIX"]["PROD"]
+    DEFAULT_PROD_PREFIX: Final[str] = config["BOT_INFO"]["PROD_PREFIX"]
     PROD_COG_IGNORE_LIST: Final[set[str]] = set(os.getenv("PROD_COG_IGNORE_LIST", "").split(","))
 
     # Dev env
     DEV: Final[str | None] = os.getenv("DEV")
     DEV_TOKEN: Final[str] = os.getenv("DEV_TOKEN", "")
-    DEFAULT_DEV_PREFIX: Final[str] = config["DEFAULT_PREFIX"]["DEV"]
+    DEFAULT_DEV_PREFIX: Final[str] = config["BOT_INFO"]["DEV_PREFIX"]
     DEV_COG_IGNORE_LIST: Final[set[str]] = set(os.getenv("DEV_COG_IGNORE_LIST", "").split(","))
+
+    # Bot info
+    BOT_NAME: Final[str] = config["BOT_INFO"]["BOT_NAME"]
+    BOT_VERSION: Final[str] = config["BOT_INFO"]["BOT_VERSION"]
+    ACTIVITIES: Final[str] = config["BOT_INFO"]["ACTIVITIES"]
 
     # Debug env
     DEBUG: Final[bool] = bool(os.getenv("DEBUG", "True"))
@@ -87,6 +92,10 @@ class Config:
     LEVELS_EXPONENT: Final[int] = config["XP"]["LEVELS_EXPONENT"]
     SHOW_XP_PROGRESS: Final[bool] = config["XP"].get("SHOW_XP_PROGRESS", False)
     ENABLE_XP_CAP: Final[bool] = config["XP"].get("ENABLE_XP_CAP", True)
+
+    # Snippet stuff
+    LIMIT_TO_ROLE_IDS: Final[bool] = config["SNIPPETS"]["LIMIT_TO_ROLE_IDS"]
+    ACCESS_ROLE_IDS: Final[list[int]] = config["SNIPPETS"]["ACCESS_ROLE_IDS"]
 
 
 CONFIG = Config()


### PR DESCRIPTION
## Description

Lets you configure things like bot name, bot version, etc easily and also fixed some snippet hardcoding

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## Summary by Sourcery

Update the settings system to support configurable bot name, version, and activity status. Remove Tux-specific naming and hardcoded role IDs for snippet creation, allowing for broader customization.

New Features:
- Introduce variable substitution in activity names, supporting placeholders like `{member_count}`, `{guild_count}`, `{bot_name}`, `{bot_version}`, and `{prefix}`.

Enhancements:
- Allow customization of the bot name, version, and activity status through the settings system.
- Replace hardcoded role IDs for snippet creation with configurable role IDs.
- Improve the help command message for self-hosted instances.

Tests:
- Update tests to reflect the changes in the settings system and snippet creation.