### PR TITLE
feat: enhance bot startup logging and add cog ignore list for ATL specific cogs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ DEV_TOKEN=""
 
 SENTRY_URL=""
 
-PROD_COG_IGNORE_LIST=
+PROD_COG_IGNORE_LIST="rolecount,mail" # These are ATL specific cogs that are not needed in Tux unless you are ATL
 DEV_COG_IGNORE_LIST=
 
 GITHUB_APP_ID=

--- a/tux/bot.py
+++ b/tux/bot.py
@@ -1,11 +1,13 @@
 import asyncio
 from typing import Any
 
+from colorama import Back, Fore, Style
 from discord.ext import commands
 from loguru import logger
 
 from tux.cog_loader import CogLoader
 from tux.database.client import db
+from tux.utils.config import Config
 
 
 class Tux(commands.Bot):
@@ -48,7 +50,14 @@ class Tux(commands.Bot):
         """
         Executes actions when the bot is ready, such as connecting to Discord and running tasks.
         """
-        logger.info("Bot has connected to Discord!")
+        logger.info(f"""
+    .--.      {Back.WHITE}{Fore.BLACK}{Config.BOT_NAME} (Tux) version {Config.BOT_VERSION} has started!{Style.RESET_ALL}
+   |o_o |     Bot ID: {Style.DIM}{self.user.id if self.user else "Unknown"}{Style.RESET_ALL}
+   |:_/ |     Watching {Style.DIM}{len(self.guilds)}{Style.RESET_ALL} servers with {Style.DIM}{len(self.users)}{Style.RESET_ALL} users
+  //   \\ \\    Prefix: {Style.DIM}{Config.DEFAULT_PREFIX}{Style.RESET_ALL}
+ (|     | )   Running in {f"{Fore.RED}Development" if Config.DEV else f"{Fore.GREEN}Production"}{Style.RESET_ALL} mode
+/'\\_   _/`\\
+\\___)=(___/ """)
 
         if not self.setup_task.done():
             await self.setup_task
@@ -71,16 +80,16 @@ class Tux(commands.Bot):
         await self.close()
 
         if tasks := [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]:
-            logger.debug(f"Cancelling {len(tasks)} outstanding tasks.")
+            logger.debug(f"Cancelling {len(tasks)} outstanding tasks: {', '.join([task.get_name() for task in tasks])}")
 
             for task in tasks:
                 task.cancel()
 
             await asyncio.gather(*tasks, return_exceptions=True)
-            logger.debug("All tasks cancelled.")
+            logger.debug("All tasks cancelled!")
 
         try:
-            logger.info("Closing database connections.")
+            logger.debug("Closing database connections.")
             await db.disconnect()
 
         except Exception as e:

--- a/tux/cog_loader.py
+++ b/tux/cog_loader.py
@@ -31,6 +31,9 @@ class CogLoader(commands.Cog):
 
         cog_name: str = filepath.stem
 
+        if cog_name in self.cog_ignore_list:
+            logger.warning(f"Skipping {cog_name} as it is in the ignore list.")
+
         return (
             filepath.suffix == ".py"
             and cog_name not in self.cog_ignore_list

--- a/tux/cogs/admin/git.py
+++ b/tux/cogs/admin/git.py
@@ -86,8 +86,7 @@ class Git(commands.Cog):
         aliases=["ci"],
     )
     @commands.guild_only()
-    # @checks.has_pl(8)
-    @commands.has_any_role("Root", "Admin", "Contributor", "Tux Contributor", "Tux Beta Tester", "%wheel")
+    @checks.has_pl(8)
     async def create_issue(self, ctx: commands.Context[Tux], title: str, body: str) -> None:
         """
         Create an issue.

--- a/tux/cogs/guild/rolecount.py
+++ b/tux/cogs/guild/rolecount.py
@@ -6,6 +6,10 @@ from reactionmenu import ViewButton, ViewMenu
 from tux.bot import Tux
 from tux.ui.embeds import EmbedCreator
 
+# FIXME: THIS IS A ALL THINGS LINUX SPECIFIC FILE
+# This will be moved to a plugin as soon as possible
+# Please do not enable this cog in your bot if you are not All Things Linux
+
 des_ids = [
     [1175177565086953523, "_kde"],
     [1175177703066968114, "_gnome"],


### PR DESCRIPTION
## Summary by Sourcery

Improve bot startup logging to display version, ID, server/user counts, prefix, and environment. Add an ignore list to the cog loader to prevent loading specific cogs.

New Features:
- Display richer information on bot startup, including version, ID, server and user counts, prefix, and environment.

Tests:
- Restore permission level check for the `create_issue` command.