### PR TITLE
Add option to hide bot owner in help command

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -6,6 +6,7 @@ BOT_INFO:
   DEV_PREFIX: "~" # You can enable dev mode in .env
   BOT_NAME: "Tux" # This may not apply everywhere, WIP (Best to keep it as Tux for now). Help command will be changed to be less Tux-specific if you change this.
   BOT_VERSION: "git" # vX.Y.Z or git
+  HIDE_BOT_OWNER: false # Hide bot owner and sysadmin from help command
   # Available substitutions:
   # {member_count} - total member count of all guilds
   # {guild_count} - total guild count

--- a/tux/help.py
+++ b/tux/help.py
@@ -268,6 +268,12 @@ class TuxHelp(commands.HelpCommand):
             value="[Help contribute! View Repo](https://github.com/allthingslinux/tux)",
             inline=True,
         )
+        embed.add_field(
+            name="Bot Info",
+            value=f"""Running {"Tux" if CONFIG.BOT_NAME == "Tux" else CONFIG.BOT_NAME + "(Tux)"} version {CONFIG.BOT_VERSION} in {"Development" if CONFIG.DEV else "Production"} mode.
+{f"This tux instance is administrated by <@{CONFIG.BOT_OWNER_ID}>" if not CONFIG.HIDE_BOT_OWNER and CONFIG.BOT_OWNER_ID else ""}""",
+            inline=False,
+        )
 
     async def send_cog_help(self, cog: commands.Cog) -> None:
         """Sends a help message for a specific cog."""

--- a/tux/utils/config.py
+++ b/tux/utils/config.py
@@ -34,6 +34,7 @@ class Config:
     BOT_NAME: Final[str] = config["BOT_INFO"]["BOT_NAME"]
     BOT_VERSION: Final[str] = config["BOT_INFO"]["BOT_VERSION"]
     ACTIVITIES: Final[str] = config["BOT_INFO"]["ACTIVITIES"]
+    HIDE_BOT_OWNER: Final[bool] = config["BOT_INFO"]["HIDE_BOT_OWNER"]
 
     # Debug env
     DEBUG: Final[bool] = bool(os.getenv("DEBUG", "True"))


### PR DESCRIPTION
Introduce a configuration option to hide the bot owner in the help command, while also displaying the bot owner and version information when the option is disabled.

## Summary by Sourcery

New Features:
- Allow hiding the bot owner in the help command via a configuration option.