### PR TITLE
add chmod 777 to danger warning

### DIFF
--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -5,7 +5,7 @@ from typing import Any
 import discord
 from loguru import logger
 
-harmful_command_pattern = r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*([/\∕~]\s*|\*|/bin|/boot|/etc|/lib|/proc|/root|/sbin|/sys|/tmp|/usr|/var|/var/log|/network.|/system)(\s+--no-preserve-root|\s+\*)*|:\(\)\{ :|:& \};:"  # noqa: RUF001
+harmful_command_pattern = r"(?:sudo\s+|doas\s+|run0\s+)?rm\s+(-[frR]*|--force|--recursive|--no-preserve-root|\s+)*([/\∕~]\s*|\*|/bin|/boot|/etc|/lib|/proc|/root|/sbin|/sys|/tmp|/usr|/var|/var/log|/network.|/system)(\s+--no-preserve-root|\s+\*)*|:\(\)\{ :|:& \};:|(?:sudo\s+|doas\s+)?chmod\s+777\s+(/\S+|\*)"  # noqa: RUF001
 
 
 def is_harmful(command: str) -> bool:


### PR DESCRIPTION
The change ive made is quite simple, it appends the `harmful_command_pattern` to additionally detect `chmod 777` 

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [ X ] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Not applicable

## Screenshots (if applicable)

Not applicable

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Bug Fixes:
- Prevent users from running `chmod 777` which could cause security vulnerabilities.