### PR TITLE
Use commands.Range.

### DIFF
--- a/tux/utils/flags.py
+++ b/tux/utils/flags.py
@@ -122,7 +122,7 @@ def get_matching_string(arg: str) -> str:
 
 
 class BanFlags(commands.FlagConverter, case_insensitive=True, delimiter=" ", prefix="-"):
-    purge_days: int = commands.flag(
+    purge_days: commands.Range[int, 1, 7] = commands.flag(
         name="purge_days",
         description="Number of days in messages. (< 7)",
         aliases=["p", "purge"],
@@ -142,7 +142,7 @@ class TempBanFlags(commands.FlagConverter, case_insensitive=True, delimiter=" ",
         description="Number of days the ban will last for.",
         aliases=["t", "d", "e", "expires", "time"],
     )
-    purge_days: int = commands.flag(
+    purge_days: commands.Range[int, 1, 7] = commands.flag(
         name="purge_days",
         description="Number of days in messages. (< 7)",
         aliases=["p"],


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use `commands.Range` to enforce that `purge_days` is between 1 and 7 in the `BanFlags` and `TempBanFlags` classes.