### PR TITLE
fix(moderation): Enable the slowmode command to be used on voice, sta…

### DIFF
--- a/tux/cogs/moderation/slowmode.py
+++ b/tux/cogs/moderation/slowmode.py
@@ -12,6 +12,11 @@ class Slowmode(commands.Cog):
     def __init__(self, bot: Tux) -> None:
         self.bot = bot
 
+    # Channel type containing a list of all discord channel types that provide the edit() method and have the slowmode_delay attribute
+    editable_channel = (
+        discord.TextChannel | discord.VoiceChannel | discord.Thread | discord.StageChannel | discord.ForumChannel
+    )
+
     @commands.hybrid_command(
         name="slowmode",
         aliases=["sm"],
@@ -60,7 +65,7 @@ class Slowmode(commands.Cog):
         ctx: commands.Context[Tux],
         first_arg: str,
         second_arg: str | None = None,
-    ) -> tuple[str | None, discord.TextChannel | discord.Thread | None]:
+    ) -> tuple[str | None, editable_channel | None]:
         action = None
         channel = None
 
@@ -84,13 +89,24 @@ class Slowmode(commands.Cog):
         return action, channel
 
     @staticmethod
-    def _get_channel(ctx: commands.Context[Tux]) -> discord.TextChannel | discord.Thread | None:
-        return ctx.channel if isinstance(ctx.channel, discord.TextChannel | discord.Thread) else None
+    def _get_channel(ctx: commands.Context[Tux]) -> editable_channel | None:
+        return (
+            ctx.channel
+            if isinstance(
+                ctx.channel,
+                discord.TextChannel
+                | discord.VoiceChannel
+                | discord.Thread
+                | discord.StageChannel
+                | discord.ForumChannel,
+            )
+            else None
+        )
 
     @staticmethod
     async def _get_slowmode(
         ctx: commands.Context[Tux],
-        channel: discord.TextChannel | discord.Thread,
+        channel: editable_channel,
     ) -> None:
         try:
             await ctx.send(
@@ -105,7 +121,7 @@ class Slowmode(commands.Cog):
     async def _set_slowmode(
         self,
         ctx: commands.Context[Tux],
-        channel: discord.TextChannel | discord.Thread,
+        channel: editable_channel,
         delay: str,
     ) -> None:
         delay_seconds = self._parse_delay(delay)


### PR DESCRIPTION
…ge, and forum channels, in addition to regular text channels and threads

## Description

Created a new type, editable_channel, containing all channel types that provide the edit() method, and replaced the hardcoded channel types with it. replaced every hardcoded list of channel types being replaced by it. the _get_channel method was separately modified to accept these additional channel types.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

This patch was tested on my local Tux test instance and confirmed to work as intended without generating any errors

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Enhancements:
- Generalize the slowmode command to support voice, stage, and forum channels by introducing a new type alias `editable_channel` that encompasses all channel types with the `edit()` method and `slowmode_delay` attribute.