### PR TITLE
add different messages for different types of harmful commands

### DIFF
--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -45,14 +45,17 @@ class EventHandler(commands.Cog):
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, all directory contents will be deleted. There is no undo. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )
+            return
         if harmful == "FORK_BOMB":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, all the memory in your system will be used. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )
+            return
         if harmful == "DD_COMMAND":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, your disk will be overwritten or erased irreversibly. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )
+            return
         if harmful == "FORMAT_COMMAND":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, your disk will be formatted. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",

--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -39,20 +39,21 @@ class EventHandler(commands.Cog):
             return
 
         stripped_content = strip_formatting(message.content)
+        harmful = is_harmful(stripped_content)
 
-        if is_harmful(stripped_content) == "RM_COMMAND":
+        if harmful == "RM_COMMAND":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, all directory contents will be deleted. There is no undo. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )
-        if is_harmful(stripped_content) == "FORK_BOMB":
+        if harmful == "FORK_BOMB":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, all the memory in your system will be used. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )
-        if is_harmful(stripped_content) == "DD_COMMAND":
+        if harmful == "DD_COMMAND":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, your disk will be overwritten or erased irreversibly. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )
-        if is_harmful(stripped_content) == "FORMAT_COMMAND":
+        if harmful == "FORMAT_COMMAND":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, your disk will be formatted. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )

--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -40,9 +40,21 @@ class EventHandler(commands.Cog):
 
         stripped_content = strip_formatting(message.content)
 
-        if is_harmful(stripped_content):
+        if is_harmful(stripped_content) == "RM_COMMAND":
             await message.reply(
                 "-# ⚠️ **This command is likely harmful. By running it, all directory contents will be deleted. There is no undo. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
+            )
+        if is_harmful(stripped_content) == "FORK_BOMB":
+            await message.reply(
+                "-# ⚠️ **This command is likely harmful. By running it, all the memory in your system will be used. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
+            )
+        if is_harmful(stripped_content) == "DD_COMMAND":
+            await message.reply(
+                "-# ⚠️ **This command is likely harmful. By running it, your disk will be overwritten or erased irreversibly. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
+            )
+        if is_harmful(stripped_content) == "FORMAT_COMMAND":
+            await message.reply(
+                "-# ⚠️ **This command is likely harmful. By running it, your disk will be formatted. Ensure you fully understand the consequences before proceeding. If you have received this message in error, please disregard it.**",
             )
 
     @commands.Cog.listener()

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -26,7 +26,7 @@ DANGEROUS_DD_COMMANDS = r"dd\s+.*of=/dev/([hs]d[a-z]|nvme\d+n\d+)"
 FORMAT_COMMANDS = r"mkfs\..*\s+/dev/([hs]d[a-z]|nvme\d+n\d+)"
 
 
-def is_harmful(command: str) -> str:
+def is_harmful(command: str) -> str | None:
     # sourcery skip: assign-if-exp, boolean-if-exp-identity, reintroduce-else
     """
     Check if a command is potentially harmful to the system.

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -26,7 +26,7 @@ DANGEROUS_DD_COMMANDS = r"dd\s+.*of=/dev/([hs]d[a-z]|nvme\d+n\d+)"
 FORMAT_COMMANDS = r"mkfs\..*\s+/dev/([hs]d[a-z]|nvme\d+n\d+)"
 
 
-def is_harmful(command: str) -> bool:
+def is_harmful(command: str) -> str:
     # sourcery skip: assign-if-exp, boolean-if-exp-identity, reintroduce-else
     """
     Check if a command is potentially harmful to the system.
@@ -44,18 +44,20 @@ def is_harmful(command: str) -> bool:
     # Normalize command by removing all whitespace for fork bomb check
     normalized = "".join(command.strip().lower().split())
     if normalized in FORK_BOMB_PATTERNS:
-        return True
+        return "FORK_BOMB"
 
     # Check for dangerous rm commands
     if re.search(DANGEROUS_RM_COMMANDS, command, re.IGNORECASE):
-        return True
+        return "RM_COMMAND"
 
     # Check for dangerous dd commands
     if re.search(DANGEROUS_DD_COMMANDS, command, re.IGNORECASE):
-        return True
+        return "DD_COMMAND"
 
     # Check for format commands
-    return bool(re.search(FORMAT_COMMANDS, command, re.IGNORECASE))
+    if bool(re.search(FORMAT_COMMANDS, command, re.IGNORECASE)):
+        return "FORMAT_COMMAND"
+    return None
 
 
 def strip_formatting(content: str) -> str:


### PR DESCRIPTION
fixes #759

## Summary by Sourcery

Enhance harmful command detection to provide more specific warning messages for different types of potentially destructive commands

Bug Fixes:
- Improve the precision of harmful command detection by returning specific command types instead of a generic boolean

Enhancements:
- Modify the is_harmful function to return specific types of harmful commands
- Add targeted warning messages for different destructive command types like rm, fork bomb, dd, and format commands