### PR TITLE
fix(snippets): removed snippet content field from si command, added a…

### DIFF
--- a/tux/cogs/utility/snippets.py
+++ b/tux/cogs/utility/snippets.py
@@ -325,7 +325,6 @@ class Snippets(commands.Cog):
             value=f"{author.mention if author else f'<@!{snippet.snippet_user_id}>'}",
             inline=False,
         )
-        embed.add_field(name="Content", value=f"> {snippet.snippet_content}", inline=False)
         embed.add_field(name="Uses", value=snippet.uses, inline=False)
         embed.add_field(name="Locked", value="Yes" if snippet.locked else "No", inline=False)
 
@@ -383,6 +382,15 @@ class Snippets(commands.Cog):
             await self.send_snippet_error(
                 ctx,
                 description="Snippet name must be alphanumeric (allows dashes only) and less than 20 characters.",
+            )
+            return
+
+        # The message placed before the snippet text adds 20 characters plus the name.
+        # Check the snippet and make sure this doesn't push it over discord's 2000 character limit.
+        if len(content) > 1980 - len(name):
+            await self.send_snippet_error(
+                ctx,
+                description=f"Snippet and name must be less than 1980 characters in length! (length: {len(content)})",
             )
             return
 


### PR DESCRIPTION
… character limit check to the cs command

## Description

Fixed 2 bugs in the snippet command relating to snippets with large content sizes.
* The si (snippet information) command would fail to run on snippets with more than 1024 characters. the problem field has been removed at kaizen's request.
* the regular snippet command can fail to run on overly large snippets due to the discord character limit. a check was added to ensure that the combined length of the snippet content and header containing the name cannot exceed 2000 characters.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Relevant commands were tested in my own tux test instance

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Improve snippet command handling by removing content field from snippet information and adding character limit checks

Bug Fixes:
- Removed problematic content field from snippet information command that could cause failures with snippets over 1024 characters
- Added character length validation to prevent snippet creation that would exceed Discord's 2000 character message limit