### PR TITLE
feat(fun): Added cowsay cog

### DIFF
--- a/tux/cogs/fun/cowsay.py
+++ b/tux/cogs/fun/cowsay.py
@@ -32,7 +32,12 @@ class Cowsay(commands.Cog):
     )
     @commands.guild_only()
     async def cowsay(
-        self, ctx: commands.Context[Tux], message: str, creature: str = "cow", eyes: str = "o", curviness: bool = True,
+        self,
+        ctx: commands.Context[Tux],
+        message: str,
+        creature: str = "cow",
+        eyes: str = "o",
+        curviness: bool = True,
     ) -> None:
         """
         cowsay command
@@ -50,6 +55,8 @@ class Cowsay(commands.Cog):
         eyes: str
             What char to use for the eyes
         """
+
+        # Creature dict. "?" will be replaced with the user-specified eye character.
         creatures = {
             "cow": r"""
     \   ^__^
@@ -68,8 +75,7 @@ class Cowsay(commands.Cog):
      \___)=(___/""",
             "puffy": r"""
     \
-     \
-               |    .
+     \         |    .
            .   |L  /|
        _ . |\ _| \--+._/| .
       / ||\| Y J  )   / |/| ./

--- a/tux/cogs/fun/cowsay.py
+++ b/tux/cogs/fun/cowsay.py
@@ -32,7 +32,7 @@ class Cowsay(commands.Cog):
     )
     @commands.guild_only()
     async def cowsay(
-        self, ctx: commands.Context[Tux], message: str, creature: str = "cow", eyes: str = "o", curviness: bool = True
+        self, ctx: commands.Context[Tux], message: str, creature: str = "cow", eyes: str = "o", curviness: bool = True,
     ) -> None:
         """
         cowsay command

--- a/tux/cogs/fun/cowsay.py
+++ b/tux/cogs/fun/cowsay.py
@@ -12,15 +12,16 @@ class Cowsay(commands.Cog):
         self.cowsay.usage = generate_usage(self.cowsay)
 
     # Helper function that word-wraps text and surrounds it with an ascii art box
-    async def draw_textbox(self, message: str) -> str:
+    async def draw_textbox(self, message: str, curviness: bool) -> str:
         message_lines = wrap(message, 40)
         max_line_length = max(len(line) for line in message_lines)
-        border = f"/{'-' * (max_line_length + 2)}\\\n"
+        corners = ["╭", "╮", "╰", "╯"] if curviness else ["/", "\\", "\\", "/"]
+        border = f"{corners[0]}{'-' * (max_line_length + 2)}{corners[1]}\n"
 
         message_box_lines = [
             border,
             *[f"| {line}{' ' * (max_line_length - len(line))} |\n" for line in message_lines],
-            f"\\{'-' * (max_line_length + 2)}/",
+            f"{corners[2]}{'-' * (max_line_length + 2)}{corners[3]}",
         ]
 
         return "".join(message_box_lines)
@@ -30,7 +31,9 @@ class Cowsay(commands.Cog):
         aliases=["cow"],
     )
     @commands.guild_only()
-    async def cowsay(self, ctx: commands.Context[Tux], message: str, creature: str = "cow") -> None:
+    async def cowsay(
+        self, ctx: commands.Context[Tux], message: str, creature: str = "cow", eyes: str = "o", curviness: bool = True
+    ) -> None:
         """
         cowsay command
 
@@ -42,26 +45,27 @@ class Cowsay(commands.Cog):
             The message to encode
         creature : str
             Which creature to use for the drawing
+        curviness: bool
+            whether to use slashes or curves for the box corners
+        eyes: str
+            What char to use for the eyes
         """
         creatures = {
             "cow": r"""
     \   ^__^
-     \  (oo)\_______
+     \  (??)\_______
         (__)\       )\/\
             ||----w |
-            ||     ||
-                """,
+            ||     ||""",
             "tux": r"""
     \
-     \
-         .--.
-        |o_o |
+     \   .--.
+        |?_? |
         |:_/ |
        //   \ \
       (|     | )
      /'\_   _/`\
-     \___)=(___/
-                """,
+     \___)=(___/""",
             "puffy": r"""
     \
      \
@@ -72,8 +76,8 @@ class Cowsay(commands.Cog):
      J  |)'( |        ` F`.'/
    -<|  F         __     .-<
      | /       .-'. `.  /-. L___
-     J \      <    \  | | O\|.-'
-   _J \  .-    \/ O | | \  |F
+     J \      <    \  | | ?\|.-'
+   _J \  .-    \/ ? | | \  |F
   '-F  -<_.     \   .-'  `-' L__
  __J  _   _.     >-'  )._.   |-'
  `-|.'   /_.           \_|   F
@@ -85,9 +89,9 @@ class Cowsay(commands.Cog):
     |/`. `-.     `._)
        / .-.\
  VK    \ (  `\
-        `.\
-            """,
+        `.\ """,
         }
+
         if message == "":
             await ctx.send("Error! Message is empty!")
             return
@@ -105,8 +109,8 @@ class Cowsay(commands.Cog):
             await ctx.send(f"Error! Message too long! ({len(message)} > 250)")
             return
 
-        textbox = await self.draw_textbox(message)
-        await ctx.send(f"```{textbox}{creatures[creature]}```")
+        textbox = await self.draw_textbox(message, curviness)
+        await ctx.send(f"```{textbox}{creatures[creature].replace('?', eyes[0])}```")
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/cogs/fun/cowsay.py
+++ b/tux/cogs/fun/cowsay.py
@@ -1,0 +1,112 @@
+from textwrap import wrap
+
+from discord.ext import commands
+
+from tux.bot import Tux
+from tux.utils.flags import generate_usage
+
+
+class Cowsay(commands.Cog):
+    def __init__(self, bot: Tux) -> None:
+        self.bot = bot
+        self.cowsay.usage = generate_usage(self.cowsay)
+
+    async def draw_textbox(self, message: str) -> str:
+        message_lines = wrap(message, 40)
+        max_line_length = max(len(line) for line in message_lines)
+        message_box_lines: list[str] = []
+        message_box_lines.append("/" + ("-" * (max_line_length + 2)) + "\\\n")
+        for line in message_lines:
+            box_line = "| " + line + (" " * (max_line_length - len(line))) + " |\n"
+            message_box_lines.append(box_line)
+        message_box_lines.append("\\" + ("-" * (max_line_length + 2)) + "/")
+        return "".join(message_box_lines)
+
+    @commands.hybrid_group(
+        name="cowsay",
+        aliases=["cow"],
+    )
+    @commands.guild_only()
+    async def cowsay(self, ctx: commands.Context[Tux], message: str, creature: str = "cow") -> None:
+        """
+        xkcd related commands.
+
+        Parameters
+        ----------
+        ctx : commands.Context[Tux]
+            The context object for the command.
+        message : str
+            The message to encode
+        creature : str
+            Which creature to use for the drawing
+        """
+        creatures = {
+            "cow": r"""
+    \   ^__^
+     \  (oo)\_______
+        (__)\       )\/\
+            ||----w |
+            ||     ||
+                """,
+            "tux": r"""
+    \
+     \
+         .--.
+        |o_o |
+        |:_/ |
+       //   \ \
+      (|     | )
+     /'\_   _/`\
+     \___)=(___/
+                """,
+            "puffy": r"""
+    \
+     \
+               |    .
+           .   |L  /|
+       _ . |\ _| \--+._/| .
+      / ||\| Y J  )   / |/| ./
+     J  |)'( |        ` F`.'/
+   -<|  F         __     .-<
+     | /       .-'. `.  /-. L___
+     J \      <    \  | | O\|.-'
+   _J \  .-    \/ O | | \  |F
+  '-F  -<_.     \   .-'  `-' L__
+ __J  _   _.     >-'  )._.   |-'
+ `-|.'   /_.           \_|   F
+   /.-   .                _.<
+  /'    /.'             .'  `\
+   /L  /'   |/      _.-'-\
+  /'J       ___.---'\|
+    |\  .--' V  | `. `
+    |/`. `-.     `._)
+       / .-.\
+ VK    \ (  `\
+        `.\
+            """,
+        }
+
+        if creature not in creatures:
+            valid_creatures: list[str] = []
+            for idx, key in enumerate(creatures.keys()):
+                if idx < len(creatures) - 1:
+                    valid_creatures.append(f"{key}, ")
+                else:
+                    valid_creatures.append(f" and {key}")
+
+            await ctx.send(
+                f'Error: "{creature}" is not a valid creature! valid creatures are: {"".join(valid_creatures)}',
+                ephemeral=True,
+            )
+            return
+
+        if len(message) > 250:
+            await ctx.send(f"Error! Message too long! ({len(message)} > 250)")
+            return
+
+        textbox = await self.draw_textbox(message)
+        await ctx.send("```" + textbox + creatures[creature] + "```")
+
+
+async def setup(bot: Tux) -> None:
+    await bot.add_cog(Cowsay(bot))

--- a/tux/cogs/fun/cowsay.py
+++ b/tux/cogs/fun/cowsay.py
@@ -11,15 +11,18 @@ class Cowsay(commands.Cog):
         self.bot = bot
         self.cowsay.usage = generate_usage(self.cowsay)
 
+    # Helper function that word-wraps text and surrounds it with an ascii art box
     async def draw_textbox(self, message: str) -> str:
         message_lines = wrap(message, 40)
         max_line_length = max(len(line) for line in message_lines)
-        message_box_lines: list[str] = []
-        message_box_lines.append("/" + ("-" * (max_line_length + 2)) + "\\\n")
-        for line in message_lines:
-            box_line = "| " + line + (" " * (max_line_length - len(line))) + " |\n"
-            message_box_lines.append(box_line)
-        message_box_lines.append("\\" + ("-" * (max_line_length + 2)) + "/")
+        border = f"/{'-' * (max_line_length + 2)}\\\n"
+
+        message_box_lines = [
+            border,
+            *[f"| {line}{' ' * (max_line_length - len(line))} |\n" for line in message_lines],
+            f"\\{'-' * (max_line_length + 2)}/",
+        ]
+
         return "".join(message_box_lines)
 
     @commands.hybrid_group(
@@ -29,7 +32,7 @@ class Cowsay(commands.Cog):
     @commands.guild_only()
     async def cowsay(self, ctx: commands.Context[Tux], message: str, creature: str = "cow") -> None:
         """
-        xkcd related commands.
+        cowsay command
 
         Parameters
         ----------
@@ -85,17 +88,15 @@ class Cowsay(commands.Cog):
         `.\
             """,
         }
+        if message == "":
+            await ctx.send("Error! Message is empty!")
+            return
 
         if creature not in creatures:
-            valid_creatures: list[str] = []
-            for idx, key in enumerate(creatures.keys()):
-                if idx < len(creatures) - 1:
-                    valid_creatures.append(f"{key}, ")
-                else:
-                    valid_creatures.append(f" and {key}")
-
+            keys = list(creatures.keys())
+            valid_creatures = ", ".join(keys[:-1]) + " and " + keys[-1] if len(keys) > 1 else keys[0]
             await ctx.send(
-                f'Error: "{creature}" is not a valid creature! valid creatures are: {"".join(valid_creatures)}',
+                f'Error: "{creature}" is not a valid creature! Valid creatures are: {valid_creatures}',
                 ephemeral=True,
             )
             return
@@ -105,7 +106,7 @@ class Cowsay(commands.Cog):
             return
 
         textbox = await self.draw_textbox(message)
-        await ctx.send("```" + textbox + creatures[creature] + "```")
+        await ctx.send(f"```{textbox}{creatures[creature]}```")
 
 
 async def setup(bot: Tux) -> None:


### PR DESCRIPTION
## Description
Added a new cog, cowsay.py, under the fun category.
This cog implements a new command, `cowsay <message> [creature]`, which will take the provided message, place it in a textbox, and add the specified creature underneath it, similarly to the well-known cowsay program

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

command has been tested in as many conditions as possible using my test instance

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/90b703b2-be09-469c-8e47-74692423fdb2)

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Add a new cowsay command to the bot's fun category, allowing users to generate ASCII art messages with various creatures

New Features:
- Implement a cowsay command that generates ASCII art messages with customizable creatures like cow, tux, and puffy

Enhancements:
- Create a flexible text wrapping mechanism for generating message boxes
- Support multiple creature options for the cowsay command