### PR TITLE
feat(snippets): add alias support; refactor permission checks

### DIFF
--- a/prisma/schema/commands/snippets.prisma
+++ b/prisma/schema/commands/snippets.prisma
@@ -1,12 +1,13 @@
 model Snippet {
   snippet_id         BigInt   @id @default(autoincrement())
   snippet_name       String
-  snippet_content    String
+  snippet_content    String?  // optional cause of snippet aliases
   snippet_user_id    BigInt
   snippet_created_at DateTime @default(now())
   guild_id           BigInt
   uses               BigInt   @default(0)
   locked             Boolean  @default(false)
+  alias              String?  // name of another snippet
   guild              Guild    @relation(fields: [guild_id], references: [guild_id])
 
   @@unique([snippet_name, guild_id])

--- a/tux/database/controllers/snippet.py
+++ b/tux/database/controllers/snippet.py
@@ -58,6 +58,26 @@ class SnippetController:
             },
         )
 
+    async def create_snippet_alias(
+        self,
+        snippet_name: str,
+        snippet_alias: str,
+        snippet_created_at: datetime.datetime,
+        snippet_user_id: int,
+        guild_id: int,
+    ) -> Snippet:
+        await self.ensure_guild_exists(guild_id)
+
+        return await self.table.create(
+            data={
+                "snippet_name": snippet_name,
+                "alias": snippet_alias,
+                "snippet_created_at": snippet_created_at,
+                "snippet_user_id": snippet_user_id,
+                "guild_id": guild_id,
+            },
+        )
+
     async def delete_snippet_by_id(self, snippet_id: int) -> None:
         await self.table.delete(where={"snippet_id": snippet_id})
 


### PR DESCRIPTION
## Description

add snippet alias support by creating a snippet with the content being the name of another snippet and refactor some stuff

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

tested in dev tux instance

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Enhance snippet functionality by adding alias support and refactoring permission checks for snippet management

New Features:
- Add support for snippet aliases, allowing users to create snippets that reference other existing snippets
- Implement automatic alias creation when a snippet's content matches an existing snippet name

Enhancements:
- Refactor permission checks for snippet operations to use a centralized snippet_check method
- Simplify snippet management logic by consolidating permission and validation checks
- Remove separate force delete snippet command in favor of a more flexible permission system

Chores:
- Clean up and remove redundant code related to snippet permission checks
- Improve logging for snippet operations