### PR TITLE
feat(utility): Self timeout

### DIFF
--- a/prisma/schema/commands/afk.prisma
+++ b/prisma/schema/commands/afk.prisma
@@ -3,8 +3,10 @@ model AFKModel {
   nickname  String
   reason    String
   since     DateTime @default(now())
+  until     DateTime?
   guild_id  BigInt
-  perm_afk Boolean  @default(false)
+  enforced  Boolean  @default(false)
+  perm_afk  Boolean  @default(false)
   guild     Guild    @relation(fields: [guild_id], references: [guild_id])
 
   @@unique([member_id, guild_id])

--- a/tux/cogs/utility/__init__.py
+++ b/tux/cogs/utility/__init__.py
@@ -1,0 +1,55 @@
+import contextlib
+from datetime import datetime
+from types import NoneType
+
+import discord
+
+from tux.database.controllers import DatabaseController
+from tux.utils.constants import CONST
+
+__all__ = ("add_afk", "del_afk")
+
+
+def _generate_afk_nickname(display_name: str) -> str:
+    """Generates the AFK nickname, handling truncation if necessary."""
+    prefix_len = len(CONST.AFK_PREFIX)
+
+    if len(display_name) >= CONST.NICKNAME_MAX_LENGTH - prefix_len:
+        suffix_len = len(CONST.AFK_TRUNCATION_SUFFIX)
+        available_space = CONST.NICKNAME_MAX_LENGTH - prefix_len - suffix_len
+        truncated_name = f"{display_name[:available_space]}{CONST.AFK_TRUNCATION_SUFFIX}"
+
+        return f"{CONST.AFK_PREFIX}{truncated_name}"
+
+    return f"{CONST.AFK_PREFIX}{display_name}"
+
+
+async def add_afk(
+    db: DatabaseController,
+    reason: str,
+    target: discord.Member,
+    guild_id: int,
+    is_perm: bool,
+    until: datetime | NoneType | None = None,
+    enforced: bool = False,
+) -> None:
+    """Sets a member as AFK, updates their nickname, and saves to the database."""
+    new_name = _generate_afk_nickname(target.display_name)
+
+    await db.afk.insert_afk(target.id, target.display_name, reason, guild_id, is_perm, until, enforced)
+
+    # Suppress Forbidden errors if the bot doesn't have permission to change the nickname
+    with contextlib.suppress(discord.Forbidden):
+        await target.edit(nick=new_name)
+
+
+async def del_afk(db: DatabaseController, target: discord.Member, nickname: str) -> None:
+    """Removes a member's AFK status, restores their nickname, and updates the database."""
+    await db.afk.remove_afk(target.id)
+
+    # Suppress Forbidden errors if the bot doesn't have permission to change the nickname
+    with contextlib.suppress(discord.Forbidden):
+        # Only attempt to restore nickname if it was actually changed by add_afk
+        # Prevents resetting a manually changed nickname if del_afk is called unexpectedly
+        if target.display_name.startswith(CONST.AFK_PREFIX):
+            await target.edit(nick=nickname)

--- a/tux/cogs/utility/afk.py
+++ b/tux/cogs/utility/afk.py
@@ -15,33 +15,6 @@ from tux.utils.constants import CONST
 from tux.utils.flags import generate_usage
 
 
-async def add_afk(
-    db: AfkController,
-    reason: str,
-    target: discord.Member,
-    guild_id: int,
-    is_perm: bool,
-    until: datetime | NoneType | None = None,
-    enforced: bool = False,
-):
-    if len(target.display_name) >= CONST.NICKNAME_MAX_LENGTH - 6:
-        truncated_name = f"{target.display_name[: CONST.NICKNAME_MAX_LENGTH - 9]}..."
-        new_name = f"[AFK] {truncated_name}"
-    else:
-        new_name = f"[AFK] {target.display_name}"
-
-    await db.insert_afk(target.id, target.display_name, reason, guild_id, is_perm, until, enforced)
-
-    with contextlib.suppress(discord.Forbidden):
-        await target.edit(nick=new_name)
-
-
-async def del_afk(db: AfkController, target: discord.Member, nickname: str) -> None:
-    await db.remove_afk(target.id)
-    with contextlib.suppress(discord.Forbidden):
-        await target.edit(nick=nickname)
-
-
 # TODO: add `afk until` command, or add support for providing a timeframe in the regular `afk` and `permafk` commands
 class Afk(commands.Cog):
     def __init__(self, bot: Tux) -> None:
@@ -227,3 +200,33 @@ class Afk(commands.Cog):
 
 async def setup(bot: Tux):
     await bot.add_cog(Afk(bot))
+
+
+# Shared AFK helper functions
+# These are placed outside the main class in order to allow other cogs to import them.
+# These functions handle all of the logic of adding and removing db entries and "[AFK]" to/from nicknames
+async def add_afk(
+    db: AfkController,
+    reason: str,
+    target: discord.Member,
+    guild_id: int,
+    is_perm: bool,
+    until: datetime | NoneType | None = None,
+    enforced: bool = False,
+):
+    if len(target.display_name) >= CONST.NICKNAME_MAX_LENGTH - 6:
+        truncated_name = f"{target.display_name[: CONST.NICKNAME_MAX_LENGTH - 9]}..."
+        new_name = f"[AFK] {truncated_name}"
+    else:
+        new_name = f"[AFK] {target.display_name}"
+
+    await db.insert_afk(target.id, target.display_name, reason, guild_id, is_perm, until, enforced)
+
+    with contextlib.suppress(discord.Forbidden):
+        await target.edit(nick=new_name)
+
+
+async def del_afk(db: AfkController, target: discord.Member, nickname: str) -> None:
+    await db.remove_afk(target.id)
+    with contextlib.suppress(discord.Forbidden):
+        await target.edit(nick=nickname)

--- a/tux/cogs/utility/self_timeout.py
+++ b/tux/cogs/utility/self_timeout.py
@@ -36,7 +36,7 @@ class SelfTimeout(commands.Cog):
             The reason why you are timing yourself out
         """
         if ctx.guild is None:
-            await ctx.send("Command must be run in a guild!")
+            await ctx.send("Command must be run in a guild!", ephemeral=True)
             return
 
         member = ctx.guild.get_member(ctx.author.id)
@@ -47,11 +47,11 @@ class SelfTimeout(commands.Cog):
         duration_readable = seconds_to_human_readable(duration_seconds)
 
         if duration_seconds > 604800:
-            await ctx.send("Error! duration cannot be longer than 7 days!")
+            await ctx.reply("Error! duration cannot be longer than 7 days!", ephemeral=True)
             return
 
         if duration_seconds < 300:
-            await ctx.send("Error! duration cannot be less than 5 minutes!")
+            await ctx.reply("Error! duration cannot be less than 5 minutes!", ephemeral=True)
             return
 
         entry = await self.db.afk.get_afk_member(member.id, guild_id=ctx.guild.id)

--- a/tux/cogs/utility/self_timeout.py
+++ b/tux/cogs/utility/self_timeout.py
@@ -22,13 +22,38 @@ class SelfTimeout(commands.Cog):
         self,
         member: discord.Member,
         guild_name: str,
-        duration_readable: str,
+        duration: str,
         reason: str,
     ) -> bool | NoneType:
+        """
+        Send a self-timeout confirmation dialog to a member
+
+        Parameters
+        ----------
+        member:
+            The discord user or member object representing the account to message
+
+        guild_name (str):
+            The name of the guild the confirmation is being sent from
+
+        duration (str) :
+            human readable string describing the duration of the self-timeout
+
+        reason (str):
+            Why the user has stated they are timing themself out
+
+        Returns
+        -------
+        Bool | NoneType
+            True if the user has confirmed
+            False if the user cancelled
+            None if the confirmation message failed to send
+        """
+
         view = ConfirmationDanger()
         try:
             confirmation_message = await member.send(
-                f'## WARNING\n### You are about to be timed out in the guild "{guild_name}" for {duration_readable} with the reason "{reason}".\nas soon as you confirm this, **you cannot cancel it or remove it early**. There is *no* provision for it to be removed by server staff on request. please think very carefully and make sure you\'ve entered the correct values before you proceed with this command.',
+                f'## WARNING\n### You are about to be timed out in the guild "{guild_name}" for {duration} with the reason "{reason}".\nas soon as you confirm this, **you cannot cancel it or remove it early**. There is *no* provision for it to be removed by server staff on request. please think very carefully and make sure you\'ve entered the correct values before you proceed with this command.',
                 view=view,
             )
         except discord.Forbidden:

--- a/tux/cogs/utility/self_timeout.py
+++ b/tux/cogs/utility/self_timeout.py
@@ -1,0 +1,115 @@
+import contextlib
+from datetime import UTC, datetime, timedelta
+from types import NoneType
+
+import discord
+from discord.ext import commands
+
+from tux.bot import Tux
+from tux.database.controllers import AfkController
+from tux.ui.views.confirmation import ConfirmationDanger
+from tux.utils.constants import CONST
+from tux.utils.flags import generate_usage
+from tux.utils.functions import convert_to_seconds, seconds_to_human_readable
+
+
+class SelfTimeout(commands.Cog):
+    def __init__(self, bot: Tux) -> None:
+        self.bot = bot
+        self.db = AfkController()
+        self.self_timeout.usage = generate_usage(self.self_timeout)
+
+    async def add_afk(
+        self,
+        reason: str,
+        target: discord.Member,
+        guild_id: int,
+        is_perm: bool,
+        until: datetime | NoneType | None = None,
+        enforced: bool = False,
+    ):
+        if len(target.display_name) >= CONST.NICKNAME_MAX_LENGTH - 6:
+            truncated_name = f"{target.display_name[: CONST.NICKNAME_MAX_LENGTH - 9]}..."
+            new_name = f"[AFK] {truncated_name}"
+        else:
+            new_name = f"[AFK] {target.display_name}"
+
+        await self.db.insert_afk(target.id, target.display_name, reason, guild_id, is_perm, until, enforced)
+
+        with contextlib.suppress(discord.Forbidden):
+            await target.edit(nick=new_name)
+
+    async def del_afk(self, target: discord.Member, nickname: str) -> None:
+        await self.db.remove_afk(target.id)
+        with contextlib.suppress(discord.Forbidden):
+            await target.edit(nick=nickname)
+
+    @commands.hybrid_command(
+        name="self_timeout",
+        aliases=["sto", "stimeout", "selftimeout"],
+    )
+    @commands.guild_only()
+    async def self_timeout(self, ctx: commands.Context[Tux], duration: str, *, reason: str = "No Reason.") -> None:
+        """
+        Time yourself out for a set duration
+
+        Parameters
+        ----------
+        ctx : commands.Context[Tux]
+            The context of the command
+        duration : str
+            How long the timeout should last for
+        reason : str [optional]
+            The reason why you are timing yourself out
+        """
+        if ctx.guild is None:
+            await ctx.send("Command must be run in a guild!")
+            return
+
+        member = ctx.guild.get_member(ctx.author.id)
+        if member is None:
+            return
+        duration_seconds: int = convert_to_seconds(duration)
+        duration_readable = seconds_to_human_readable(duration_seconds)
+
+        if duration_seconds > 604800:
+            await ctx.send("Error! duration cannot be longer than 7 days!")
+            return
+
+        entry = await self.db.get_afk_member(member.id, guild_id=ctx.guild.id)
+        if entry is not None and reason == "No Reason.":
+            # If the member is already afk and hasn't provided a reason with this command,
+            # assume they want to upgrade their current AFK to a self-timeout and carry the old reason
+            reason = entry.reason
+
+        view = ConfirmationDanger()
+        try:
+            confirmation_message = await member.send(
+                f'## WARNING\n### You are about to be timed out in the guild "{ctx.guild.name}" for {duration_readable} with the reason "{reason}".\nas soon as you confirm this, **you cannot cancel it or remove it early**. There is *no* provision for it to be removed by server staff on request. please think very carefully and make sure you\'ve entered the correct values before you proceed with this command.',
+                view=view,
+            )
+        except discord.Forbidden:
+            await ctx.send("Error: Tux was unable to DM you the confirmation message")
+            return
+
+        await view.wait()
+        await confirmation_message.delete()
+        if view.value:
+            await member.send(
+                f'You have timed yourself out in guild {ctx.guild.name} for {duration_readable} with the reason "{reason}".',
+            )
+            if entry is not None:
+                await self.del_afk(member, entry.nickname)
+            await member.timeout(timedelta(seconds=float(duration_seconds)), reason="self time-out")
+            await self.add_afk(
+                reason,
+                member,
+                ctx.guild.id,
+                True,
+                datetime.now(UTC) + timedelta(seconds=duration_seconds),
+                True,
+            )
+
+
+async def setup(bot: Tux):
+    await bot.add_cog(SelfTimeout(bot))

--- a/tux/cogs/utility/self_timeout.py
+++ b/tux/cogs/utility/self_timeout.py
@@ -76,6 +76,9 @@ class SelfTimeout(commands.Cog):
             await ctx.send("Error! duration cannot be longer than 7 days!")
             return
 
+        if duration_seconds < 300:
+            await ctx.send("Error! duration cannot be less than 5 minutes!")
+
         entry = await self.db.get_afk_member(member.id, guild_id=ctx.guild.id)
         if entry is not None and reason == "No Reason.":
             # If the member is already afk and hasn't provided a reason with this command,

--- a/tux/cogs/utility/self_timeout.py
+++ b/tux/cogs/utility/self_timeout.py
@@ -45,7 +45,11 @@ class SelfTimeout(commands.Cog):
             await target.edit(nick=nickname)
 
     async def request_confirmation(
-        self, member: discord.Member, guild_name: str, duration_readable: str, reason: str
+        self,
+        member: discord.Member,
+        guild_name: str,
+        duration_readable: str,
+        reason: str,
     ) -> bool | NoneType:
         view = ConfirmationDanger()
         try:

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from prisma.actions import GuildActions
 from prisma.models import AFKModel, Guild
 from tux.database.client import db
@@ -77,6 +79,8 @@ class AfkController(BaseController[AFKModel]):
         nickname: str,
         reason: str,
         guild_id: int,
+        until: datetime | None = None,
+        enforced: bool = False,
         perm_afk: bool = False,
     ) -> AFKModel:
         """Insert a new AFK record.
@@ -104,6 +108,8 @@ class AfkController(BaseController[AFKModel]):
                 "member_id": member_id,
                 "nickname": nickname,
                 "reason": reason,
+                "until": until,
+                "enforced": enforced,
                 "perm_afk": perm_afk,
                 "guild": self.connect_or_create_relation("guild_id", guild_id),
             },

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -108,10 +108,10 @@ class AfkController(BaseController[AFKModel]):
                 "member_id": member_id,
                 "nickname": nickname,
                 "reason": reason,
-                "until": until,
-                "enforced": enforced,
                 "perm_afk": perm_afk,
                 "guild": self.connect_or_create_relation("guild_id", guild_id),
+                "until": until,
+                "enforced": enforced,
             },
             include={"guild": True},
         )

--- a/tux/database/controllers/afk.py
+++ b/tux/database/controllers/afk.py
@@ -79,9 +79,9 @@ class AfkController(BaseController[AFKModel]):
         nickname: str,
         reason: str,
         guild_id: int,
+        perm_afk: bool = False,
         until: datetime | None = None,
         enforced: bool = False,
-        perm_afk: bool = False,
     ) -> AFKModel:
         """Insert a new AFK record.
 

--- a/tux/ui/views/confirmation.py
+++ b/tux/ui/views/confirmation.py
@@ -12,18 +12,25 @@ class BaseConfirmationView(discord.ui.View):
     confirm_label: str
     confirm_style: discord.ButtonStyle
 
-    def __init__(self) -> None:
+    def __init__(self, user: int) -> None:
         super().__init__()
         self.value: bool | None = None
+        self.user = user
 
     @discord.ui.button(label="PLACEHOLDER", style=discord.ButtonStyle.secondary, custom_id="confirm")
     async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button[discord.ui.View]) -> None:
+        if interaction.user.id is not self.user:
+            await interaction.response.send_message("This interaction is locked to the command author.", ephemeral=True)
+            return
         await interaction.response.send_message("Confirming", ephemeral=True)
         self.value = True
         self.stop()
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey)
     async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button[discord.ui.View]) -> None:
+        if interaction.user.id is not self.user:
+            await interaction.response.send_message("This interaction is locked to the command author.", ephemeral=True)
+            return
         await interaction.response.send_message("Cancelling", ephemeral=True)
         self.value = False
         self.stop()
@@ -36,16 +43,16 @@ class BaseConfirmationView(discord.ui.View):
 
 
 class ConfirmationDanger(BaseConfirmationView):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, user: int) -> None:
+        super().__init__(user)
         self.confirm_label = "I understand and wish to proceed anyway"
         self.confirm_style = discord.ButtonStyle.danger
         self.update_button_styles()
 
 
 class ConfirmationNormal(BaseConfirmationView):
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, user: int) -> None:
+        super().__init__(user)
         self.confirm_label = "Confirm"
         self.confirm_style = discord.ButtonStyle.green
         self.update_button_styles()

--- a/tux/ui/views/confirmation.py
+++ b/tux/ui/views/confirmation.py
@@ -1,6 +1,12 @@
 import discord
 
 
+# Confirmation dialog view:
+# This view is to be used for a confirmation dialog.
+# ideally it should be sent as a DM to ensure the user requesting it is the only one able to interact.
+# The base class implements the buttons themselves,
+# and the subclasses, which are intended to be imported and used in cogs,
+# change the style and labels depending on severity of the action being confirmed.
 class BaseConfirmationView(discord.ui.View):
     confirm_label: str
     confirm_style: discord.ButtonStyle

--- a/tux/ui/views/confirmation.py
+++ b/tux/ui/views/confirmation.py
@@ -1,33 +1,34 @@
 import discord
 
-
 # Confirmation dialog view:
 # This view is to be used for a confirmation dialog.
 # ideally it should be sent as a DM to ensure the user requesting it is the only one able to interact.
 # The base class implements the buttons themselves,
 # and the subclasses, which are intended to be imported and used in cogs,
 # change the style and labels depending on severity of the action being confirmed.
+
+
 class BaseConfirmationView(discord.ui.View):
     confirm_label: str
     confirm_style: discord.ButtonStyle
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.value: bool | None = None
 
     @discord.ui.button(label="PLACEHOLDER", style=discord.ButtonStyle.secondary, custom_id="confirm")
-    async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
+    async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button[discord.ui.View]) -> None:
         await interaction.response.send_message("Confirming", ephemeral=True)
         self.value = True
         self.stop()
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey)
-    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
+    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button[discord.ui.View]) -> None:
         await interaction.response.send_message("Cancelling", ephemeral=True)
         self.value = False
         self.stop()
 
-    def update_button_styles(self):
+    def update_button_styles(self) -> None:
         for item in self.children:
             if isinstance(item, discord.ui.Button) and item.custom_id == "confirm":
                 item.label = self.confirm_label
@@ -35,7 +36,7 @@ class BaseConfirmationView(discord.ui.View):
 
 
 class ConfirmationDanger(BaseConfirmationView):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.confirm_label = "I understand and wish to proceed anyway"
         self.confirm_style = discord.ButtonStyle.danger
@@ -43,7 +44,7 @@ class ConfirmationDanger(BaseConfirmationView):
 
 
 class ConfirmationNormal(BaseConfirmationView):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.confirm_label = "Confirm"
         self.confirm_style = discord.ButtonStyle.green

--- a/tux/ui/views/confirmation.py
+++ b/tux/ui/views/confirmation.py
@@ -1,0 +1,45 @@
+import discord
+
+
+class ConfirmationDanger(discord.ui.View):
+    def __init__(self):
+        super().__init__()
+        self.value = None
+
+    # When the confirm button is pressed, set the inner value to `True` and
+    # stop the View from listening to more input.
+    # We also send the user an ephemeral message that we're confirming their choice.
+    @discord.ui.button(label="I understand and wish to proceed anyway", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
+        await interaction.response.send_message("Confirming", ephemeral=True)
+        self.value = True
+        self.stop()
+
+    # This one is similar to the confirmation button except sets the inner value to `False`
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey)
+    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
+        await interaction.response.send_message("Cancelling", ephemeral=True)
+        self.value = False
+        self.stop()
+
+
+class ConfirmationNormal(discord.ui.View):
+    def __init__(self):
+        super().__init__()
+        self.value = None
+
+    # When the confirm button is pressed, set the inner value to `True` and
+    # stop the View from listening to more input.
+    # We also send the user an ephemeral message that we're confirming their choice.
+    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green)
+    async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
+        await interaction.response.send_message("Confirming", ephemeral=True)
+        self.value = True
+        self.stop()
+
+    # This one is similar to the confirmation button except sets the inner value to `False`
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey)
+    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
+        await interaction.response.send_message("Cancelling", ephemeral=True)
+        self.value = False
+        self.stop()

--- a/tux/ui/views/confirmation.py
+++ b/tux/ui/views/confirmation.py
@@ -1,45 +1,44 @@
 import discord
 
 
-class ConfirmationDanger(discord.ui.View):
+class BaseConfirmationView(discord.ui.View):
+    confirm_label: str
+    confirm_style: discord.ButtonStyle
+
     def __init__(self):
         super().__init__()
-        self.value = None
+        self.value: bool | None = None
 
-    # When the confirm button is pressed, set the inner value to `True` and
-    # stop the View from listening to more input.
-    # We also send the user an ephemeral message that we're confirming their choice.
-    @discord.ui.button(label="I understand and wish to proceed anyway", style=discord.ButtonStyle.danger)
+    @discord.ui.button(label="PLACEHOLDER", style=discord.ButtonStyle.secondary, custom_id="confirm")
     async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
         await interaction.response.send_message("Confirming", ephemeral=True)
         self.value = True
         self.stop()
 
-    # This one is similar to the confirmation button except sets the inner value to `False`
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey)
     async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
         await interaction.response.send_message("Cancelling", ephemeral=True)
         self.value = False
         self.stop()
 
+    def update_button_styles(self):
+        for item in self.children:
+            if isinstance(item, discord.ui.Button) and item.custom_id == "confirm":
+                item.label = self.confirm_label
+                item.style = self.confirm_style
 
-class ConfirmationNormal(discord.ui.View):
+
+class ConfirmationDanger(BaseConfirmationView):
     def __init__(self):
         super().__init__()
-        self.value = None
+        self.confirm_label = "I understand and wish to proceed anyway"
+        self.confirm_style = discord.ButtonStyle.danger
+        self.update_button_styles()
 
-    # When the confirm button is pressed, set the inner value to `True` and
-    # stop the View from listening to more input.
-    # We also send the user an ephemeral message that we're confirming their choice.
-    @discord.ui.button(label="Confirm", style=discord.ButtonStyle.green)
-    async def confirm(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
-        await interaction.response.send_message("Confirming", ephemeral=True)
-        self.value = True
-        self.stop()
 
-    # This one is similar to the confirmation button except sets the inner value to `False`
-    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.grey)
-    async def cancel(self, interaction: discord.Interaction, button: discord.ui.Button):  # type: ignore
-        await interaction.response.send_message("Cancelling", ephemeral=True)
-        self.value = False
-        self.stop()
+class ConfirmationNormal(BaseConfirmationView):
+    def __init__(self):
+        super().__init__()
+        self.confirm_label = "Confirm"
+        self.confirm_style = discord.ButtonStyle.green
+        self.update_button_styles()

--- a/tux/utils/constants.py
+++ b/tux/utils/constants.py
@@ -65,5 +65,9 @@ class Constants:
     # Message timings
     DEFAULT_DELETE_AFTER = 30
 
+    # AFK constants
+    AFK_PREFIX = "[AFK] "
+    AFK_TRUNCATION_SUFFIX = "..."
+
 
 CONST = Constants()

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -205,7 +205,7 @@ def seconds_to_human_readable(seconds: int) -> str:
     for unit, div in units:
         amount, seconds = divmod(int(seconds), div)
         if amount > 0:
-            parts.append("{} {}{}".format(amount, unit, "" if amount == 1 else "s"))
+            parts.append(f"{amount} {unit}{'' if amount == 1 else 's'}")
     return ", ".join(parts)
 
 

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -177,6 +177,38 @@ def convert_to_seconds(time_str: str) -> int:
     return 0 if current_value != 0 else total_seconds
 
 
+def seconds_to_human_readable(seconds: int) -> str:
+    """
+    Converts a number of seconds into a human readable string
+
+    Parameters
+    ----------
+    seconds : int
+        The number of seconds to convert
+
+    Returns
+    -------
+    str
+        A string that breaks the time down by months, weeks, days, hours, minutes, and seconds.
+    """
+    units = (
+        ("month", 2592000),
+        ("week", 604800),
+        ("day", 86400),
+        ("hour", 3600),
+        ("minute", 60),
+        ("second", 1),
+    )
+    if seconds == 0:
+        return "zero seconds"
+    parts: list[str] = []
+    for unit, div in units:
+        amount, seconds = divmod(int(seconds), div)
+        if amount > 0:
+            parts.append("{} {}{}".format(amount, unit, "" if amount == 1 else "s"))
+    return ", ".join(parts)
+
+
 def datetime_to_unix(dt: datetime | None) -> str:
     """
     This function accepts a datetime object or None, converts it into a Unix timestamp


### PR DESCRIPTION
## Description

This branch adds a self-timeout command which can be used to lock oneself from a guild for a set time period. 
In order to implement this, it also adds support for expiration times to the AFK system.
- AFK db entries have 2 additional fields: until, and enforced.
  - Until contains a datetime object that describes when an AFK status should be removed automatically
  - enforced is a bool that indicates if a user's AFK status is being enforced using a timeout or other method.
- A task loop has been added to the AFK cog that checks through every AFK status and removes any that are expired every 2 minutes.
- When an AFK user is mentioned, Tux will now include the date and time the AFK status expires if it is set
- A new view, Confirmation, has been added to tux/ui/views
  - This view contains 2 confirmation dialog types: ConfirmationDanger and ConfirmationNormal
  - these are intended to be used for confirmation dialogs for commands that can cause harm if used improperly
- A new utils function, seconds_to_human_readable, has been added that converts a number in seconds to a human-readable string

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

The changes have been fully tested using my own test instance of Tux

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/7768f4a4-fe15-4c48-868b-d7f6371128f6)
![image](https://github.com/user-attachments/assets/8330ecea-8ae4-4b84-9ff7-64421e2c7e40)
![image](https://github.com/user-attachments/assets/ce9ef9d8-4fb3-4aea-ba1c-e6b295d230b9)

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Implement a self-timeout feature for Discord bot Tux, enhancing the AFK system with time-limited status and adding a new confirmation view for sensitive actions

New Features:
- Add a self-timeout command that allows users to lock themselves out of a guild for a specified duration
- Introduce support for time-limited AFK statuses with expiration tracking

Enhancements:
- Extend AFK system to support temporary AFK statuses with expiration times
- Add a task loop to automatically remove expired AFK statuses
- Improve AFK mention messages to include expiration time when applicable

Tests:
- Tested changes using a personal test instance of Tux

Chores:
- Create utility functions for converting seconds to human-readable time formats

## Summary by Sourcery

Implement a self-timeout feature for Discord bot Tux, enhancing the AFK system with time-limited status and adding confirmation views for sensitive actions

New Features:
- Add a self-timeout command that allows users to lock themselves out of a guild for a specified duration
- Introduce support for time-limited AFK statuses with expiration tracking

Enhancements:
- Extend AFK system to support temporary AFK statuses with expiration times
- Add a task loop to automatically remove expired AFK statuses
- Improve AFK mention messages to include expiration time when applicable

Tests:
- Tested changes using a personal test instance of Tux

Chores:
- Create utility functions for converting seconds to human-readable time formats