### PR TITLE
Fix/issue 816

### DIFF
--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -1,9 +1,11 @@
 from discord import AllowedMentions
 from discord.ext import commands
+from reactionmenu import ViewButton, ViewMenu
 
 from tux.bot import Tux
 from tux.utils.flags import generate_usage
 
+# from tux.utils.functions import truncate
 from . import SnippetsBaseCog
 
 
@@ -75,7 +77,28 @@ class Snippet(SnippetsBaseCog):
 
             text += f"|| {snippet.snippet_content}"
 
-        await ctx.send(text, allowed_mentions=AllowedMentions.none())
+        # pagination if text > 2000 characters
+        if len(text) <= 2000:
+            await ctx.send(text, allowed_mentions=AllowedMentions.none())
+            return
+
+        menu = ViewMenu(
+            ctx,
+            menu_type=ViewMenu.TypeText,
+            all_can_click=True,
+            show_page_director=False,
+            timeout=180,
+            delete_on_timeout=True,
+        )
+
+        for i in range(0, len(text), 2000):
+            page: str = text[i : i + 2000]
+            menu.add_page(content=page)
+
+        menu.add_button(ViewButton.back())
+        menu.add_button(ViewButton.next())
+
+        await menu.start()
 
 
 async def setup(bot: Tux) -> None:

--- a/tux/database/controllers/snippet.py
+++ b/tux/database/controllers/snippet.py
@@ -233,6 +233,25 @@ class SnippetController(BaseController[Snippet]):
             include={"guild": True},
         )
 
+    async def get_all_aliases(self, snippet_name: str, guild_id: int) -> list[Snippet]:
+        """Get all aliases for a snippet name within a guild.
+
+        Parameters
+        ----------
+        snippet_name : str
+            The name of the snippet to find aliases for.
+        guild_id : int
+            The ID of the guild to search within.
+
+        Returns
+        -------
+        list[Snippet]
+            A list of Snippet objects representing the aliases.
+        """
+        return await self.find_many(
+            where={"alias": {"equals": snippet_name, "mode": "insensitive"}, "guild_id": guild_id},
+        )
+
     async def update_snippet_by_id(self, snippet_id: int, snippet_content: str) -> Snippet | None:
         """Update a snippet's content.
 

--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -26,6 +26,27 @@ DANGEROUS_DD_COMMANDS = r"dd\s+.*of=/dev/([hs]d[a-z]|nvme\d+n\d+)"
 FORMAT_COMMANDS = r"mkfs\..*\s+/dev/([hs]d[a-z]|nvme\d+n\d+)"
 
 
+def truncate(text: str, length: int) -> str:
+    """Truncates a string to a specified length.
+
+    If the string is longer than the specified length, it will be truncated
+    and an ellipsis will be appended. Otherwise, the original string is returned.
+
+    Parameters
+    ----------
+    text : str
+        The string to truncate.
+    length : int
+        The maximum length of the string.
+
+    Returns
+    -------
+    str
+        The truncated string.
+    """
+    return text if len(text) <= length else f"{text[: length - 3]}..."
+
+
 def is_harmful(command: str) -> str | None:
     # sourcery skip: assign-if-exp, boolean-if-exp-identity, reintroduce-else
     """


### PR DESCRIPTION
# Fixes #816: Snippet commands, specifically `snippet` and `snippetinfo` would error out when snippet content exceeds discords allowed character limit.

Snippetinfo specifically would error out due to it being within an embed field, which has a character limit of 1024 characters. I added a truncate function to avoid this and improved the look of the embed as well as added all snippet aliases upon request. 

With the snippet command, there is a possibility of users creating snippets with content exceed 2000 characters. Instead of limiting the users input, I paginated the content to fix potential errors.

## How Has This Been Tested? (if applicable)

Tested in Tux's development server, which is open to the public.

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/66cddf8a-8854-4111-b735-64d57010fd4e)
![image](https://github.com/user-attachments/assets/9ca9a8d3-8607-40bf-acbd-a9c210c2a3cf)

## Additional Information

In future, i think the entire snippet system can be reworked and made less load intensive by caching snippets per guild.

## Summary by Sourcery

Improve snippet command functionality by adding pagination and truncation to handle long snippet content and embed field limitations

New Features:
- Created a new EmojiManager to centralize emoji handling
- Added method to retrieve all aliases for a snippet

Bug Fixes:
- Fixed issues with snippet commands failing when content exceeds Discord's character limits
- Added pagination for snippet content over 2000 characters
- Implemented truncation for snippet info embed fields to prevent exceeding 1024 character limit

Enhancements:
- Added support for displaying snippet aliases
- Improved emoji management with a new EmojiManager class
- Refactored case list and snippet info embed rendering