### PR TITLE
fix(afk): misc fixes for self-timeout

### DIFF
--- a/tux/cogs/moderation/clearafk.py
+++ b/tux/cogs/moderation/clearafk.py
@@ -47,9 +47,12 @@ class ClearAFK(commands.Cog):
 
         await self.db.remove_afk(member.id)
 
-        if entry and entry.nickname:
-            with contextlib.suppress(discord.Forbidden):
-                await member.edit(nick=entry.nickname)  # Reset nickname to original
+        if entry:
+            if entry.nickname:
+                with contextlib.suppress(discord.Forbidden):
+                    await member.edit(nick=entry.nickname)  # Reset nickname to original
+            if entry.enforced:  # untimeout the user if  the afk status is a self-timeout
+                await member.timeout(None, reason="removing self-timeout")
 
         return await ctx.send(f"AFK status for {member.mention} has been cleared.", ephemeral=True)
 

--- a/tux/cogs/utility/afk.py
+++ b/tux/cogs/utility/afk.py
@@ -152,6 +152,11 @@ class Afk(commands.Cog):
         if message.author.bot:
             return
 
+        # Check if the message is a self-timeout command.
+        # if it is, the member is probably trying to upgrade to a self-timeout, so AFK status should not be removed.
+        if message.content.startswith("$sto"):
+            return
+
         afks_mentioned: list[tuple[discord.Member, AFKModel]] = []
 
         for mentioned in message.mentions:

--- a/tux/cogs/utility/self_timeout.py
+++ b/tux/cogs/utility/self_timeout.py
@@ -47,7 +47,7 @@ class SelfTimeout(commands.Cog):
         duration_readable = seconds_to_human_readable(duration_seconds)
 
         if duration_seconds == 0:
-            await ctx.reply("Error! Invalid time format")
+            await ctx.reply("Error! Invalid time format", ephemeral=True)
             return
 
         if duration_seconds > 604800:

--- a/tux/cogs/utility/self_timeout.py
+++ b/tux/cogs/utility/self_timeout.py
@@ -46,6 +46,10 @@ class SelfTimeout(commands.Cog):
         duration_seconds: int = convert_to_seconds(duration)
         duration_readable = seconds_to_human_readable(duration_seconds)
 
+        if duration_seconds == 0:
+            await ctx.reply("Error! Invalid time format")
+            return
+
         if duration_seconds > 604800:
             await ctx.reply("Error! duration cannot be longer than 7 days!", ephemeral=True)
             return


### PR DESCRIPTION
- Added handling for self-timeout removal to the clearafk command
- fixed race condition where afk status would be removed before the reason cary-over system in self-timeout could handle the entry
- added error message for invalid time formatting to self-timeout command

## Description

This patch contains a few minor bugfixes for issues that cropped up with the self-timeout system in production use.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Please describe how you tested your code. e.g describe what commands you ran, what arguments, and any config stuff (if applicable)

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Improve self-timeout and AFK management functionality with several bug fixes and error handling improvements

Bug Fixes:
- Fixed race condition in AFK status removal during self-timeout
- Added proper handling for self-timeout removal in clearafk command
- Prevented AFK status removal during self-timeout command execution

Enhancements:
- Added validation for time format in self-timeout command
- Improved error messaging for invalid time inputs