### PR TITLE
fix(levels): Allow checking levels of members that are no longer in t…

### DIFF
--- a/tux/cogs/levels/level.py
+++ b/tux/cogs/levels/level.py
@@ -21,7 +21,7 @@ class Level(commands.Cog):
         name="level",
         aliases=["lvl", "rank", "xp"],
     )
-    async def level(self, ctx: commands.Context[Tux], member: discord.Member | None = None) -> None:
+    async def level(self, ctx: commands.Context[Tux], member: discord.User | discord.Member | None = None) -> None:
         """
         Fetches the XP and level for a member (or the person who runs the command if no member is provided).
 
@@ -30,7 +30,7 @@ class Level(commands.Cog):
         ctx : commands.Context[Tux]
             The context object for the command.
 
-        member : discord.Member
+        member : discord.User
             The member to fetch XP and level for.
         """
 
@@ -39,8 +39,7 @@ class Level(commands.Cog):
             return
 
         if member is None:
-            member = ctx.author if isinstance(ctx.author, discord.Member) else None
-            assert member
+            member = ctx.author
 
         xp: float = await self.db.levels.get_xp(member.id, ctx.guild.id)
         level: int = await self.db.levels.get_level(member.id, ctx.guild.id)


### PR DESCRIPTION
…he guild

## Description

Changed level command to use the discord.User type instead of only discord.Member. getting a disscord.Member for a user not in the guild will error, while users can be grabbed regardless.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Patch was tested on my test instance and confirmed to allow checking the levels of banned members and even people who have never been in the guild

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Modify the level command to support checking levels for users who are not currently guild members

Bug Fixes:
- Extend level command to work with discord.User type, allowing level checks for users not currently in the guild

Enhancements:
- Update type hinting to accept both discord.User and discord.Member for more flexible level checking