### PR TITLE
fix(afk): make afk command responses ephemeral

### DIFF
--- a/tux/cogs/utility/afk.py
+++ b/tux/cogs/utility/afk.py
@@ -53,13 +53,14 @@ class Afk(commands.Cog):
 
         await add_afk(self.db, shortened_reason, target, ctx.guild.id, False)
 
-        await ctx.send(
+        await ctx.reply(
             content="\N{SLEEPING SYMBOL} || You are now afk! " + f"Reason: `{shortened_reason}`",
             allowed_mentions=discord.AllowedMentions(
                 users=False,
                 everyone=False,
                 roles=False,
             ),
+            ephemeral=True,
         )
 
     @commands.hybrid_command(name="permafk")
@@ -84,7 +85,7 @@ class Afk(commands.Cog):
         entry = await self.db.afk.get_afk_member(target.id, guild_id=ctx.guild.id)
         if entry is not None:
             await del_afk(self.db, target, entry.nickname)
-            await ctx.send("Welcome back!")
+            await ctx.send("Welcome back!", ephemeral=True)
             return
 
         shortened_reason = textwrap.shorten(reason, width=100, placeholder="...")
@@ -99,6 +100,7 @@ class Afk(commands.Cog):
                 everyone=False,
                 roles=False,
             ),
+            ephemeral=True,
         )
 
     @commands.Cog.listener("on_message")


### PR DESCRIPTION
## Description

updated response messages in the afk cog to include ephemeral=True, so that when invoked as a slash command the messages do not appear to other members

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Please describe how you tested your code. e.g describe what commands you ran, what arguments, and any config stuff (if applicable)

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Update AFK command responses to be ephemeral when used as slash commands

Bug Fixes:
- Made AFK command responses ephemeral to prevent visibility to other members

Enhancements:
- Modified ctx.send() and ctx.reply() methods to include ephemeral=True parameter