### PR TITLE
fix(tldr): condense tldr pages

### DIFF
--- a/tux/cogs/utility/tldr.py
+++ b/tux/cogs/utility/tldr.py
@@ -121,7 +121,26 @@ class Tldr(commands.Cog):
         if command.startswith("-"):
             return "Invalid command: Command can't start with a dash (-)."
 
-        return self._run_subprocess(["tldr", "-r", command], "No TLDR page found.")
+        output = self._run_subprocess(["tldr", "-r", command], "No TLDR page found.")
+        # Process output: escape leading dashes and inline code
+        lines = output.splitlines()
+        formatted_lines: list[str] = []
+        for i, raw in enumerate(lines):
+            # remove blank between dash and backtick
+            if (
+                not raw.strip()
+                and i > 0
+                and i < len(lines) - 1
+                and lines[i - 1].startswith("-")
+                and lines[i + 1].startswith("`")
+            ):
+                continue
+            line = raw
+            # escape leading dash
+            if line.startswith("-"):
+                line = "\\" + line
+            formatted_lines.append(line)
+        return "\n".join(formatted_lines)
 
     def get_tldrs(self) -> list[str]:
         """


### PR DESCRIPTION
## Description
closes #842 
adds backslash to prevent discord list formatting and removes not needed newlines

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

ran /tldr test

## Screenshots (if applicable)
before and after
![image](https://github.com/user-attachments/assets/a0235cea-5d80-427d-970b-03d48f41a263)
![image](https://github.com/user-attachments/assets/c8b52ed0-1af9-4ff4-a29f-c5a59a6dad84)

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Improve formatting of tldr command output to enhance readability and compatibility with Discord.

Bug Fixes:
- Prevent Discord list formatting by escaping leading dashes in tldr output.
- Remove unnecessary blank lines between list items and code blocks in tldr output.