### PR TITLE
fix(tty_roles.py): handle role assignment errors

### DIFF
--- a/tux/cogs/services/tty_roles.py
+++ b/tux/cogs/services/tty_roles.py
@@ -100,6 +100,13 @@ class TtyRoles(commands.Cog):
             await discord.utils.sleep_until(datetime.datetime.now(datetime.UTC) + datetime.timedelta(seconds=5))
             await member.add_roles(role)
 
+        except discord.NotFound as error:
+            # check if the member left the server
+            if member.guild.get_member(member.id) is None:
+                logger.info(f"Member {member} left or got kicked by the server before the role could be assigned.")
+                return
+            logger.error(f"Failed to assign role {role.name} to {member}: {error}")
+
         except Exception as error:
             logger.error(f"Failed to assign role {role.name} to {member}: {error}")
 


### PR DESCRIPTION
fixes issue if user is kicked/leaves within 5 seconds

## Summary by Sourcery

Bug Fixes:
- Catch discord.NotFound during delayed role assignment to detect if the member left or was kicked and log an info message instead of an error.