### PR TITLE
fix(DEVELOPER.md): fix broken cli usage link

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -17,7 +17,7 @@ Explore the following pages for more detailed information on specific developmen
 * **[Local Development](./docs/content/dev/local_development.md)**
   * Running the bot locally.
   * Understanding the hot reloading mechanism.
-* **[Tux CLI Usage](./docs/content/dev/cli_usage.md)**
+* **[Tux CLI Usage](./docs/content/dev/cli/index.md)**
   * Understanding development vs. production modes (`--dev`, `--prod`).
   * Overview of command groups (`bot`, `db`, `dev`, `docker`).
 * **[Database Management](./docs/content/dev/database.md)**


### PR DESCRIPTION
## Bug Description

This pull request fixes a broken link in DEVELOPER.md by updating the reference to the Tux CLI Usage documentation to the correct file path.

## Summary by Sourcery

Bug Fixes:
- Update Tux CLI Usage link in DEVELOPER.md to point to docs/content/dev/cli/index.md instead of the old path.