### PR TITLE
fix(function): fix strip_formatting function regex

### DIFF
--- a/tux/utils/functions.py
+++ b/tux/utils/functions.py
@@ -96,9 +96,9 @@ def strip_formatting(content: str) -> str:
         The string with formatting stripped.
     """
     # Remove triple backtick blocks
-    content = re.sub(r"```[\s\S]*?```", "", content)
+    content = re.sub(r"```(.*?)```", r"\1", content)
     # Remove single backtick code blocks
-    content = re.sub(r"`[^`]+`", "", content)
+    content = re.sub(r"`([^`]*)`", r"\1", content)
     # Remove Markdown headers
     content = re.sub(r"^#+\s+", "", content, flags=re.MULTILINE)
     # Remove markdown formatting characters, but preserve |


### PR DESCRIPTION
## Description

fixes the strip_formatting function regex that caused strings with codeblock ticks to return a empty string and not trigger the is_harmful functions

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

locally hosted and tested in ATL's dev server

## Summary by Sourcery

Fix strip_formatting to preserve text within Markdown code fences instead of removing it, ensuring harmful content detection triggers correctly for backtick-enclosed strings.

Bug Fixes:
- Update triple backtick regex to capture and retain inner content rather than drop entire block
- Adjust single backtick regex to preserve code content inside backticks instead of deleting it