### PR TITLE
feat(snippets): change snippet command behavior

### DIFF
--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -1,4 +1,4 @@
-from discord import AllowedMentions
+from discord import AllowedMentions, Message
 from discord.ext import commands
 from reactionmenu import ViewButton, ViewMenu
 
@@ -79,7 +79,14 @@ class Snippet(SnippetsBaseCog):
 
         # pagination if text > 2000 characters
         if len(text) <= 2000:
-            await ctx.send(text, allowed_mentions=AllowedMentions.none())
+            if ctx.message.reference and ctx.message.reference.resolved:
+                reference = ctx.message.reference.resolved
+                if isinstance(reference, Message):
+                    await reference.reply(text, allowed_mentions=AllowedMentions.none())
+                else:
+                    await ctx.send(text, allowed_mentions=AllowedMentions.none())
+            else:
+                await ctx.send(text, allowed_mentions=AllowedMentions.none())
             return
 
         menu = ViewMenu(

--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -79,6 +79,7 @@ class Snippet(SnippetsBaseCog):
 
         # pagination if text > 2000 characters
         if len(text) <= 2000:
+            # Check if there is a message being replied to
             if ctx.message.reference and ctx.message.reference.resolved:
                 reference = ctx.message.reference.resolved
                 if isinstance(reference, Message):

--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -80,14 +80,11 @@ class Snippet(SnippetsBaseCog):
         # pagination if text > 2000 characters
         if len(text) <= 2000:
             # Check if there is a message being replied to
-            if ctx.message.reference and ctx.message.reference.resolved:
-                reference = ctx.message.reference.resolved
-                if isinstance(reference, Message):
-                    await reference.reply(text, allowed_mentions=AllowedMentions.none())
-                else:
-                    await ctx.reply(text, allowed_mentions=AllowedMentions.none())
-            else:
-                await ctx.reply(text, allowed_mentions=AllowedMentions.none())
+            reference = getattr(ctx.message.reference, "resolved", None)
+            # Set reply target if it exists, otherwise use the context message
+            reply_target = reference if isinstance(reference, Message) else ctx
+
+            await reply_target.reply(text, allowed_mentions=AllowedMentions.none())
             return
 
         menu = ViewMenu(

--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -85,9 +85,9 @@ class Snippet(SnippetsBaseCog):
                 if isinstance(reference, Message):
                     await reference.reply(text, allowed_mentions=AllowedMentions.none())
                 else:
-                    await ctx.send(text, allowed_mentions=AllowedMentions.none())
+                    await ctx.reply(text, allowed_mentions=AllowedMentions.none())
             else:
-                await ctx.send(text, allowed_mentions=AllowedMentions.none())
+                await ctx.reply(text, allowed_mentions=AllowedMentions.none())
             return
 
         menu = ViewMenu(


### PR DESCRIPTION
## Description

resolves #870 and changes snippet behavior to reply to the command

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

locally hosted and tested in ATL's dev server

## Summary by Sourcery

Enhancements:
- Change snippet command to reply to the invoking or referenced message instead of sending a standalone message.