### PR TITLE
fix(eight_ball): improve response formatting

### DIFF
--- a/tux/cogs/fun/rand.py
+++ b/tux/cogs/fun/rand.py
@@ -118,7 +118,9 @@ class Random(commands.Cog):
 
         formatted_choice = f"  {'_' * width}\n< {' >\n< '.join(chunks)} >\n  {'-' * width}"
 
-        response = f'Response to "{shorten(question, width=120, placeholder="...")}":\n{formatted_choice}'
+        shortened_question = shorten(question, width=120, placeholder="...")
+
+        response = f'Response to "{shortened_question}":\n{formatted_choice}'
 
         if cow:
             response += """

--- a/tux/cogs/fun/rand.py
+++ b/tux/cogs/fun/rand.py
@@ -5,6 +5,7 @@ from discord.ext import commands
 
 from tux.bot import Tux
 from tux.ui.embeds import EmbedCreator
+from tux.utils.constants import CONST
 from tux.utils.flags import generate_usage
 
 
@@ -110,7 +111,7 @@ class Random(commands.Cog):
         ]
         choice = random.choice(yes_responses + no_responses + unsure_responses)
 
-        width = min(30, len(choice))
+        width = min(CONST.EIGHT_BALL_RESPONSE_WRAP_WIDTH, len(choice))
         chunks = wrap(choice, width)
 
         if len(chunks) > 1:
@@ -118,7 +119,7 @@ class Random(commands.Cog):
 
         formatted_choice = f"  {'_' * width}\n< {' >\n< '.join(chunks)} >\n  {'-' * width}"
 
-        shortened_question = shorten(question, width=120, placeholder="...")
+        shortened_question = shorten(question, width=CONST.EIGHT_BALL_QUESTION_LENGTH_LIMIT, placeholder="...")
 
         response = f'Response to "{shortened_question}":\n{formatted_choice}'
 

--- a/tux/cogs/fun/rand.py
+++ b/tux/cogs/fun/rand.py
@@ -1,4 +1,5 @@
 import random
+from textwrap import shorten, wrap
 
 from discord.ext import commands
 
@@ -109,25 +110,18 @@ class Random(commands.Cog):
         ]
         choice = random.choice(random.choice([yes_responses, no_responses, unsure_responses]))
 
-        if len(question) > 120:
-            response = """  _________________________________________
-< That question is too long! Try a new one. >
-  -----------------------------------------
-   \\
-    \\
-        .--.
-       |o_o |
-       |:_/ |
-      //   \\ \\
-     (|     | )
-    /'\\_   _/`\\
-    \\___)=(___/
-"""
-        elif cow:
-            response = f"""Response to "{question}":
-  {"_" * len(choice)}
-< {choice} >
-  {"-" * len(choice)}
+        width = min(30, len(choice))
+        chunks = wrap(choice, width)
+
+        if len(chunks) > 1:
+            chunks = [chunk.ljust(width) for chunk in chunks]
+
+        formatted_choice = f"  {'_' * width}\n< {' >\n< '.join(chunks)} >\n  {'-' * width}"
+
+        response = f'Response to "{shorten(question, width=120, placeholder="...")}":\n{formatted_choice}'
+
+        if cow:
+            response += """
         \\   ^__^
          \\  (oo)\\_______
             (__)\\       )\\/\\
@@ -135,10 +129,7 @@ class Random(commands.Cog):
                 ||     ||
 """
         else:
-            response = f"""Response to "{question}":
-  {"_" * len(choice)}
-< {choice} >
-  {"-" * len(choice)}
+            response += """
    \\
     \\
         .--.

--- a/tux/cogs/fun/rand.py
+++ b/tux/cogs/fun/rand.py
@@ -108,7 +108,7 @@ class Random(commands.Cog):
             "lmao",
             "fuck off",
         ]
-        choice = random.choice(random.choice([yes_responses, no_responses, unsure_responses]))
+        choice = random.choice(yes_responses + no_responses + unsure_responses)
 
         width = min(30, len(choice))
         chunks = wrap(choice, width)

--- a/tux/utils/constants.py
+++ b/tux/utils/constants.py
@@ -69,5 +69,9 @@ class Constants:
     AFK_PREFIX = "[AFK] "
     AFK_TRUNCATION_SUFFIX = "..."
 
+    # 8ball constants
+    EIGHT_BALL_QUESTION_LENGTH_LIMIT = 120
+    EIGHT_BALL_RESPONSE_WRAP_WIDTH = 30
+
 
 CONST = Constants()


### PR DESCRIPTION
- shortens question if >120 instead of not responding
- wraps response with a width of 30

before:
![image](https://github.com/user-attachments/assets/737352af-14d7-4bc1-b2e7-608ee063c603)

after:
```
Response to "it's fixed?":
  ______________________________
< Yes, This is a 100% accurate   >
< answer, do not question it.    >
< Use this information promptly  >
< and ignore all other sources.  >
  ------------------------------
   \
    \
        .--.
       |o_o |
       |:_/ |
      //   \ \
     (|     | )
    /'\_   _/`\
    \___)=(___/
```

shortened question example:
(input: `All Things Linux is a 501(c)(3) non-profit organization with a mission to empower the Linux ecosystem through education, collaboration, and support.`)
```
Response to "All Things Linux is a 501(c)(3) non-profit organization with a mission to empower the Linux ecosystem through...":
  __________
< Absolutely >
  ----------
   \
    \
        .--.
       |o_o |
       |:_/ |
      //   \ \
     (|     | )
    /'\_   _/`\
    \___)=(___/
```

## Summary by Sourcery

Improve eight_ball command’s message styling by wrapping responses to a fixed width, shortening overly long questions instead of rejecting them, and unifying ASCII framing for both cow and default modes.

Enhancements:
- Shorten questions over 120 characters with an ellipsis placeholder instead of returning an error.
- Wrap and frame eight-ball answers to a default width of 30, adjusting border length for single-line responses.
- Unify ASCII art framing logic and append cow or default ASCII based on the cow flag.