### PR TITLE
Improve the run command by adding extra languages and fixing longstanding issues.

### DIFF
--- a/tux/cogs/utility/run.py
+++ b/tux/cogs/utility/run.py
@@ -10,7 +10,7 @@ from tux.utils.flags import generate_usage
 from tux.wrappers import godbolt, wandbox
 
 ansi_re = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-ticks_re = re.compile(r"\```")
+ticks_re = re.compile(r"```")
 
 
 compiler_map_godbolt = {
@@ -78,7 +78,7 @@ class CodeDispatch(ABC):
 class GodboltService(CodeDispatch):
     async def _execute(self, lang: str, code: str, opts: str | None):
         if lang in {"c++", "cpp"}:
-            opts = f"{'' if opts is None else opts} -xc++ -lstdc++ -shared-libgcc"
+            opts = f"{' ' if opts is None else opts} -xc++ -lstdc++ -shared-libgcc"
 
         out = godbolt.getoutput(code, lang, opts)
         if not out:
@@ -319,7 +319,7 @@ class Run(commands.Cog):
                 title="Fatal exception occurred!",
                 description="failed to get output from the compiler.",
             )
-            await ctx.send(embed=embed, ephemeral=True, delete_after=30)
+            await ctx.send(embed=embed, delete_after=30)
             return
 
         await ctx.message.clear_reaction("<a:BreakdancePengu:1378346831250985061>")
@@ -362,7 +362,7 @@ class Run(commands.Cog):
             description=str(desc),
         )
 
-        await ctx.send(embed=embed, ephemeral=True, delete_after=30)
+        await ctx.send(embed=embed, delete_after=30)
 
     @commands.command(
         name="languages",

--- a/tux/cogs/utility/run.py
+++ b/tux/cogs/utility/run.py
@@ -90,16 +90,16 @@ class GodboltService(CodeDispatch):
 
 class WandboxService(CodeDispatch):
     async def _execute(self, lang: str, code: str, opts: str | None):
-        output = "Padding word.\n P\n A\n D\n D\n"
+        output = ""
         temp = wandbox.getoutput(code, lang, opts)
         if not temp:
             return None
         if temp["compiler_error"] != "":
-            output = output + temp["compiler_error"]
+            output = f"{output} {temp['compiler_error']}"
         if temp["program_output"] != "":
-            output = output + temp["program_output"]
+            output = f"{output} {temp['program_output']}"
 
-        return "\n".join(output.split("\n")[5:])
+        return "\n".join(output.split("\n")[1:])
 
 
 class Run(commands.Cog):

--- a/tux/cogs/utility/run.py
+++ b/tux/cogs/utility/run.py
@@ -45,6 +45,7 @@ compiler_map_wandbox = {
     "erlang": "erlang-27.1",
     "groovy": "groovy-4.0.23",
     "javascript": "nodejs-20.17.0",
+    "js": "nodejs-20.17.0",
     "lisp": "clisp-2.49",
     "lua": "lua-5.4.7",
     "nim": "nim-2.2.4",

--- a/tux/wrappers/godbolt.py
+++ b/tux/wrappers/godbolt.py
@@ -115,7 +115,7 @@ def getcompilers() -> str | None:
 
 def getspecificcompiler(lang: str) -> str | None:
     """
-    Get the specific compiler from the Godbolt API.
+    Get a specific compiler from the Godbolt API.
 
     Parameters
     ----------

--- a/tux/wrappers/wandbox.py
+++ b/tux/wrappers/wandbox.py
@@ -28,11 +28,12 @@ def getoutput(code: str, compiler: str, options: str | None) -> dict[str, Any] |
 
     copt = options if options is not None else ""
 
-    payload = {"compiler": compiler, "code": code, options: copt}
-
-    uri = client.post(url, json=payload)
+    payload = {"compiler": compiler, "code": code, "options": copt}
 
     try:
-        return uri.json() if uri.status_code == httpx.codes.OK else None
+        uri = client.post(url, json=payload)
+        uri.raise_for_status()
     except httpx.ReadTimeout:
         return None
+    else:
+        return uri.json() if uri.status_code == httpx.codes.OK else None

--- a/tux/wrappers/wandbox.py
+++ b/tux/wrappers/wandbox.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+import httpx
+
+client = httpx.Client(timeout=15)
+url = "https://wandbox.org/api/compile.json"
+
+
+def getoutput(code: str, compiler: str, options: str | None) -> dict[str, Any] | None:
+    copt = options if options is not None else ""
+
+    payload = {"compiler": compiler, "code": code, options: copt}
+
+    uri = client.post(url, json=payload)
+
+    try:
+        return uri.json() if uri.status_code == httpx.codes.OK else None
+    except httpx.ReadTimeout:
+        return None

--- a/tux/wrappers/wandbox.py
+++ b/tux/wrappers/wandbox.py
@@ -7,6 +7,25 @@ url = "https://wandbox.org/api/compile.json"
 
 
 def getoutput(code: str, compiler: str, options: str | None) -> dict[str, Any] | None:
+    """
+    Compile and execute code using a specified compiler and return the output.
+
+    Parameters
+    ----------
+    code : str
+        The source code to be compiled and executed.
+    compiler : str
+        The identifier or name of the compiler to use.
+    options : str or None
+        Additional compiler options or flags. If None, an empty string is used.
+
+    Returns
+    -------
+    dict[str, Any] or None
+        A dictionary containing the compiler output if the request is successful,
+        otherwise `None`. Returns `None` on HTTP errors or read timeout.
+    """
+
     copt = options if options is not None else ""
 
     payload = {"compiler": compiler, "code": code, options: copt}


### PR DESCRIPTION
## Description

This PR fixes a typo in the godbolt.py file, adds a minimal wrapper on top of Wandbox's API and fixes some longstanding issues with the `$run` command while upgrading compilers and adding new languages.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [Y] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

NA

## Screenshots (if applicable)

NA

## Additional Information

NA

## Summary by Sourcery

Enhance the run command by integrating Wandbox support for additional languages, upgrading compiler mappings, refactoring execution logic, and improving UI feedback and error handling.

New Features:
- Introduce a Wandbox API wrapper and integrate it into the run command
- Allow run command to fetch code from a replied message when no code is provided
- Add an interactive close button to embedded run outputs
- React to the run command invocation with a custom emoji

Bug Fixes:
- Fix typo in the godbolt wrapper docstring
- Correct backtick removal regex to properly handle triple backticks

Enhancements:
- Refactor run command into private helper methods for code sanitization and language detection
- Update compiler mappings with upgraded versions and broader language coverage
- Consolidate Godbolt and Wandbox execution logic into a single execute function
- Simplify and update the supported languages listing in the languages command embed