### PR TITLE
fix(snippets): Change snippet reply mention behaviour

### DIFF
--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -84,7 +84,10 @@ class Snippet(SnippetsBaseCog):
             # Set reply target if it exists, otherwise use the context message
             reply_target = reference if isinstance(reference, Message) else ctx
 
-            await reply_target.reply(text, allowed_mentions=AllowedMentions.none())
+            await reply_target.reply(
+                text,
+                allowed_mentions=AllowedMentions(users=False, roles=False, everyone=False, replied_user=True),
+            )
             return
 
         menu = ViewMenu(

--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -1,4 +1,4 @@
-from discord import AllowedMentions
+from discord import AllowedMentions, Message
 from discord.ext import commands
 from reactionmenu import ViewButton, ViewMenu
 
@@ -79,7 +79,14 @@ class Snippet(SnippetsBaseCog):
 
         # pagination if text > 2000 characters
         if len(text) <= 2000:
-            await ctx.send(text, allowed_mentions=AllowedMentions.none())
+            if ctx.message.reference and ctx.message.reference.resolved:
+                reference = ctx.message.reference.resolved
+                if isinstance(reference, Message):
+                    await reference.reply(text, allowed_mentions=AllowedMentions.none())
+                else:
+                    await ctx.send(text, allowed_mentions=AllowedMentions.none())
+            else:
+                await ctx.send(text, allowed_mentions=AllowedMentions.none())
             return
 
         menu = ViewMenu(

--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -79,6 +79,7 @@ class Snippet(SnippetsBaseCog):
 
         # pagination if text > 2000 characters
         if len(text) <= 2000:
+            # Check if there is a message being replied to
             if ctx.message.reference and ctx.message.reference.resolved:
                 reference = ctx.message.reference.resolved
                 if isinstance(reference, Message):

--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -80,14 +80,11 @@ class Snippet(SnippetsBaseCog):
         # pagination if text > 2000 characters
         if len(text) <= 2000:
             # Check if there is a message being replied to
-            if ctx.message.reference and ctx.message.reference.resolved:
-                reference = ctx.message.reference.resolved
-                if isinstance(reference, Message):
-                    await reference.reply(text, allowed_mentions=AllowedMentions.none())
-                else:
-                    await ctx.reply(text, allowed_mentions=AllowedMentions.none())
-            else:
-                await ctx.reply(text, allowed_mentions=AllowedMentions.none())
+            reference = getattr(ctx.message.reference, "resolved", None)
+            # Set reply target if it exists, otherwise use the context message
+            reply_target = reference if isinstance(reference, Message) else ctx
+
+            await reply_target.reply(text, allowed_mentions=AllowedMentions.none())
             return
 
         menu = ViewMenu(

--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -85,9 +85,9 @@ class Snippet(SnippetsBaseCog):
                 if isinstance(reference, Message):
                     await reference.reply(text, allowed_mentions=AllowedMentions.none())
                 else:
-                    await ctx.send(text, allowed_mentions=AllowedMentions.none())
+                    await ctx.reply(text, allowed_mentions=AllowedMentions.none())
             else:
-                await ctx.send(text, allowed_mentions=AllowedMentions.none())
+                await ctx.reply(text, allowed_mentions=AllowedMentions.none())
             return
 
         menu = ViewMenu(


### PR DESCRIPTION
Quick fix that pings the user being replied to upon a snippet call

## Summary by Sourcery

Use reply instead of send for snippet outputs and enable pinging the replied-to user when invoking the command as a reply

Bug Fixes:
- Ensure snippet replies mention the user being replied to

Enhancements:
- Detect and target the replied message when sending snippets, falling back to the command context if no reply exists