### PR TITLE
fix(snippets): Fix reply mention in snippet behavior

### DIFF
--- a/tux/cogs/snippets/get_snippet.py
+++ b/tux/cogs/snippets/get_snippet.py
@@ -84,7 +84,10 @@ class Snippet(SnippetsBaseCog):
             # Set reply target if it exists, otherwise use the context message
             reply_target = reference if isinstance(reference, Message) else ctx
 
-            await reply_target.reply(text, allowed_mentions=AllowedMentions.none())
+            await reply_target.reply(
+                text,
+                allowed_mentions=AllowedMentions(users=False, roles=False, everyone=False, replied_user=True),
+            )
             return
 
         menu = ViewMenu(


### PR DESCRIPTION
Quick fix to allow mention replies on snippet call

## Summary by Sourcery

Bug Fixes:
- Enable reply mentions for the snippet command by updating allowed_mentions to include replied_user