### PR TITLE
Jail/unjail fix

### DIFF
--- a/tux/cogs/moderation/jail.py
+++ b/tux/cogs/moderation/jail.py
@@ -156,7 +156,7 @@ class Jail(ModerationCogBase):
             if user_roles:
                 try:
                     # Try to remove all at once for efficiency
-                    await member.remove_roles(*user_roles, reason=flags.reason, atomic=False)
+                    await member.remove_roles(*user_roles, reason=flags.reason)
                 except Exception as e:
                     logger.warning(
                         f"Failed to remove all roles at once from {member}, falling back to individual removal: {e}",

--- a/tux/cogs/moderation/unjail.py
+++ b/tux/cogs/moderation/unjail.py
@@ -109,7 +109,7 @@ class Unjail(ModerationCogBase):
 
         # Try to add all roles at once
         try:
-            await member.add_roles(*roles_to_add, reason=reason, atomic=False)
+            await member.add_roles(*roles_to_add, reason=reason)
 
         except discord.Forbidden:
             logger.error(f"No permission to add roles to {member}")


### PR DESCRIPTION
## Description

There was a problem with Tux where the jail command would add and remove the jail role from the member once ran and the unjail command having the similar issue as well. The fix had to do with caching and enabling atomic for `remove_roles` and `add_roles`.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Ran the jail/unjail slash command from one of Tux dev bots.

## Screenshots (if applicable)

N/A

## Additional Information

N/A

## Summary by Sourcery

Bug Fixes:
- Remove atomic=False from remove_roles in jail command and add_roles in unjail command to enforce atomic role modifications and fix jail/unjail role assignment issues

