### PR TITLE
fix(devcontainer-workflow): correct workspace mount and folder for /a…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,8 @@
   "forwardPorts": [
     3000
   ],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
+  "workspaceFolder": "/app",
   "build": {
     "target": "dev",
     "args": {


### PR DESCRIPTION
## Description

Adjusted `workspaceMount` and `workspaceFolder` to explicitly target `/app`, resolving workflow issues caused by VS Code defaulting to `workspaces/<folder>`. This ensures correct volume binding and consistency with Dockerfile expectations.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [ - ] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

- Launched the dev container in VS Code using the updated devcontainer.json settings to confirm the workspace mounts correctly to /app.

- Verified that the development environment initializes without errors and the correct folder structure is recognized.

## Screenshots (if applicable)
N/A
## Additional Information
N/A

## Summary by Sourcery

Fix the DevContainer configuration by explicitly mounting the workspace to /app and aligning the workspaceFolder with the Dockerfile, resolving VS Code default path issues.

Bug Fixes:
- Correct workspaceMount setting to target /app instead of the default workspaces path
- Update workspaceFolder to /app to ensure consistent volume binding with the Dockerfile