### PR TITLE
fix(sentry): change log level for bot disconnection to info

### DIFF
--- a/tux/bot.py
+++ b/tux/bot.py
@@ -205,7 +205,7 @@ class Tux(commands.Bot):
         if sentry_sdk.is_initialized():
             with sentry_sdk.push_scope() as scope:
                 scope.set_tag("event_type", "disconnect")
-                scope.set_level("warning")
+                scope.set_level("info")
                 sentry_sdk.capture_message("Bot disconnected from Discord")
 
     # --- Sentry Transaction Tracking ---

--- a/tux/bot.py
+++ b/tux/bot.py
@@ -207,7 +207,7 @@ class Tux(commands.Bot):
                 scope.set_tag("event_type", "disconnect")
                 scope.set_level("info")
                 sentry_sdk.capture_message(
-                    "Bot disconnected from Discord, this happens sometimes and is fine as long as it's not hapening too often"
+                    "Bot disconnected from Discord, this happens sometimes and is fine as long as it's not hapening too often",
                 )
 
     # --- Sentry Transaction Tracking ---

--- a/tux/bot.py
+++ b/tux/bot.py
@@ -206,7 +206,9 @@ class Tux(commands.Bot):
             with sentry_sdk.push_scope() as scope:
                 scope.set_tag("event_type", "disconnect")
                 scope.set_level("info")
-                sentry_sdk.capture_message("Bot disconnected from Discord")
+                sentry_sdk.capture_message(
+                    "Bot disconnected from Discord, this happens sometimes and is fine as long as it's not hapening too often"
+                )
 
     # --- Sentry Transaction Tracking ---
 

--- a/tux/bot.py
+++ b/tux/bot.py
@@ -207,7 +207,7 @@ class Tux(commands.Bot):
                 scope.set_tag("event_type", "disconnect")
                 scope.set_level("info")
                 sentry_sdk.capture_message(
-                    "Bot disconnected from Discord, this happens sometimes and is fine as long as it's not hapening too often",
+                    "Bot disconnected from Discord, this happens sometimes and is fine as long as it's not happening too often",
                 )
 
     # --- Sentry Transaction Tracking ---


### PR DESCRIPTION
## Description

Corrects #917 by changing the log level of the bot disconnection warning.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Please describe how you tested your code. e.g describe what commands you ran, what arguments, and any config stuff (if applicable)

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Set Sentry disconnect events to info level and clarify the disconnect message

Bug Fixes:
- Change Sentry log level for bot disconnection from warning to info
- Update Sentry disconnect message to indicate occasional disconnections are normal