### PR TITLE
fix(starboard): make starboard work in threads

### DIFF
--- a/tux/cogs/services/starboard.py
+++ b/tux/cogs/services/starboard.py
@@ -9,6 +9,7 @@ from tux.bot import Tux
 from tux.database.controllers import DatabaseController
 from tux.ui.embeds import EmbedCreator, EmbedType
 from tux.utils import checks
+from tux.utils.converters import get_channel_safe
 from tux.utils.functions import generate_usage
 
 
@@ -296,8 +297,8 @@ class Starboard(commands.Cog):
         if not starboard or str(payload.emoji) != starboard.starboard_emoji:
             return
 
-        channel = self.bot.get_channel(payload.channel_id)
-        if not isinstance(channel, discord.TextChannel):
+        channel = await get_channel_safe(self.bot, payload.channel_id)
+        if channel is None:
             return
 
         try:

--- a/tux/cogs/utility/poll.py
+++ b/tux/cogs/utility/poll.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import discord
 from discord import app_commands
 from discord.ext import commands
@@ -9,6 +7,7 @@ from prisma.enums import CaseType
 from tux.bot import Tux
 from tux.database.controllers import DatabaseController
 from tux.ui.embeds import EmbedCreator
+from tux.utils.converters import get_channel_safe
 
 # TODO: Create option inputs for the poll command instead of using a comma separated string
 
@@ -74,17 +73,9 @@ class Poll(commands.Cog):
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
         # get reaction from payload.message_id, payload.channel_id, payload.guild_id, payload.emoji
-        channel = self.bot.get_channel(payload.channel_id)
+        channel = await get_channel_safe(self.bot, payload.channel_id)
         if channel is None:
-            try:
-                channel = await self.bot.fetch_channel(payload.channel_id)
-            except discord.NotFound:
-                logger.error(f"Channel not found for ID: {payload.channel_id}")
-                return
-            except (discord.Forbidden, discord.HTTPException) as fetch_error:
-                logger.error(f"Failed to fetch channel: {fetch_error}")
-                return
-        channel = cast(discord.TextChannel | discord.Thread, channel)
+            return
 
         message = await channel.fetch_message(payload.message_id)
         # Lookup the reaction object for this event


### PR DESCRIPTION
feat(converters): add get_channel_safe function

## Description

make starboard work in threads and add a get_channel_safe function to make some of this more abstracted

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

tested in a channel and in thread, temporarily disabled self star protection so it would work

setup: `%starboard setup #starboard ⭐ 1`

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Add a safe channel retrieval helper and refactor channel-fetch logic to support thread messages for starboard and polling features, including error logging.

Bug Fixes:
- Fix starboard not handling reactions in thread channels

Enhancements:
- Introduce get_channel_safe utility for abstracted and safe channel fetching with error logging
- Refactor poll and starboard listeners to use get_channel_safe instead of direct get_channel/fetch logic