### PR TITLE
fix(remindme.py): fix issue where old reminders from the old system w…

### DIFF
--- a/tux/cogs/utility/remindme.py
+++ b/tux/cogs/utility/remindme.py
@@ -72,6 +72,15 @@ class RemindMe(commands.Cog):
         dt_now = datetime.datetime.now(datetime.UTC)
 
         for reminder in reminders:
+            # hotfix for an issue where old reminders from the old system would all send at once
+            if reminder.reminder_sent:
+                try:
+                    await self.db.reminder.delete_reminder_by_id(reminder.reminder_id)
+                except Exception as e:
+                    logger.error(f"Failed to delete reminder: {e}")
+
+                continue
+
             seconds = (reminder.reminder_expires_at - dt_now).total_seconds()
 
             if seconds <= 0:


### PR DESCRIPTION
…ould all send at once

## Description

adds in a check where if they have reminder_sent set to true the reminder is deleted

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

manually added sent reminder into db and added a reminder for 1m to ensure reminders still function properly

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Clean up reminders marked as sent on bot startup to prevent legacy reminders from firing all at once.

Bug Fixes:
- Skip and delete reminders flagged as sent during startup initialization.
- Log errors encountered when deleting sent reminders without interrupting the cleanup process.