### PR TITLE
feat(encode_decode): add encoder and decoder for multiple coding systems

### DIFF
--- a/tux/cogs/utility/encode_decode.py
+++ b/tux/cogs/utility/encode_decode.py
@@ -1,0 +1,165 @@
+import base64
+import binascii
+
+from discord import AllowedMentions
+from discord.ext import commands
+
+from tux.bot import Tux
+from tux.utils.functions import generate_usage
+
+
+def wrap_strings(wrapper: str, contents: list[str]) -> list[str]:
+    return [f"{wrapper}{content}{wrapper}" for content in contents]
+
+
+allowed_mentions: AllowedMentions = AllowedMentions(
+    everyone=False,
+    users=False,
+    roles=False,
+)
+
+CODING_SYSTEMS = [
+    "base16",
+    "base32",
+    "base64",
+    "base85",
+]
+
+
+class EncodeDecode(commands.Cog):
+    def __init__(self, bot: Tux) -> None:
+        self.bot = bot
+        self.encode.usage = generate_usage(self.encode)
+        self.decode.usage = generate_usage(self.decode)
+
+    async def send_message(self, ctx: commands.Context[Tux], data: str):
+        if len(data) > 2000:
+            await ctx.reply(
+                content="The string ended up being too long. Please use this [site](https://www.base64encode.org/) instead.",
+                allowed_mentions=allowed_mentions,
+                ephemeral=True,
+            )
+            return
+
+        await ctx.reply(
+            content=data,
+            allowed_mentions=allowed_mentions,
+            ephemeral=False,
+        )
+
+    @commands.hybrid_command(
+        name="encode",
+    )
+    async def encode(
+        self,
+        ctx: commands.Context[Tux],
+        cs: str,
+        *,
+        text: str,
+    ) -> None:
+        """
+        Encode text in a coding system.
+
+        Parameters
+        ----------
+        ctx : commands.Context[Tux]
+            The context of the command.
+        cs : str
+            The coding system.
+        text : str
+            The text you want to encode.
+        """
+
+        cs = cs.lower()
+        btext = text.encode(encoding="utf-8")
+
+        try:
+            if cs == "base16":
+                data = base64.b16encode(btext)
+            elif cs == "base32":
+                data = base64.b32encode(btext)
+            elif cs == "base64":
+                data = base64.b64encode(btext)
+            elif cs == "base85":
+                data = base64.b85encode(btext)
+            else:
+                await ctx.reply(
+                    content=f"Invalid coding system. Please use: {', '.join(wrap_strings('`', CODING_SYSTEMS))}",
+                    allowed_mentions=allowed_mentions,
+                    ephemeral=True,
+                )
+                return
+
+            await self.send_message(ctx, data.decode(encoding="utf-8"))
+        except Exception as e:
+            await ctx.reply(
+                content=f"Unknown excpetion: {type(e)}: {e}",
+                allowed_mentions=allowed_mentions,
+                ephemeral=True,
+            )
+
+    @commands.hybrid_command(
+        name="decode",
+    )
+    async def decode(
+        self,
+        ctx: commands.Context[Tux],
+        cs: str,
+        *,
+        text: str,
+    ) -> None:
+        """
+        Decode text in a coding system.
+
+        Parameters
+        ----------
+        ctx : commands.Context[Tux]
+            The context of the command.
+        cs : str
+            The coding system.
+        text : str
+            The text you want to decode.
+        """
+
+        cs = cs.lower()
+        btext = text.encode(encoding="utf-8")
+
+        try:
+            if cs == "base16":
+                data = base64.b16decode(btext)
+            elif cs == "base32":
+                data = base64.b32decode(btext)
+            elif cs == "base64":
+                data = base64.b64decode(btext)
+            elif cs == "base85":
+                data = base64.b85decode(btext)
+            else:
+                await ctx.reply(
+                    content=f"Invalid coding system. Please use: {', '.join(wrap_strings('`', CODING_SYSTEMS))}",
+                    allowed_mentions=allowed_mentions,
+                    ephemeral=True,
+                )
+                return
+
+            await self.send_message(ctx, data.decode(encoding="utf-8"))
+        except binascii.Error as e:
+            await ctx.reply(
+                content=f"Decoding error: {e}",
+            )
+            return
+        except UnicodeDecodeError:
+            await ctx.reply(
+                content="The message was decoded, but the output is not valid UTF-8.",
+                allowed_mentions=allowed_mentions,
+                ephemeral=True,
+            )
+        except Exception as e:
+            await ctx.reply(
+                content=f"Unknown excpetion: {type(e)}: {e}",
+                allowed_mentions=allowed_mentions,
+                ephemeral=True,
+            )
+
+
+async def setup(bot: Tux):
+    await bot.add_cog(EncodeDecode(bot))


### PR DESCRIPTION
## Description

This PR adds a command named `encode` and `decode`. They are both used to encode and decode messages in multiple coding systems ranging from Base16 to Base85. I have made sure to error handle, document, and checked my code with ruff and pyright.

## Guidelines

- [x] My code follows the style guidelines of this project (formatted with Ruff)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [x] My changes generate no new warnings
- [x] I have tested this change
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have added all appropriate labels to this PR

- [ ] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)
I have ran the command using all available options, while also running commands which I know will error.

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

<img width="551" height="911" alt="{14EA23BB-9646-4995-83EF-7ED012C86716}" src="https://github.com/user-attachments/assets/e3a141b2-0b09-4d7b-bd85-1a055b1e2bf4" />
<img width="777" height="607" alt="{31931D59-4AF8-4817-9890-51CDBC933DDC}" src="https://github.com/user-attachments/assets/54dd1bb6-809f-4930-ad07-e3f7cfb7a180" />
<img width="778" height="609" alt="{6F921E7D-5773-460D-AAD1-600793726E76}" src="https://github.com/user-attachments/assets/4e47fa80-df6b-4b8a-ad31-f0854743f01d" />


## Summary by Sourcery

Add a new EncodeDecode cog with hybrid commands to encode and decode text in Base16, Base32, Base64, and Base85 systems, including input validation and error handling.

New Features:
- Introduce an `encode` command to convert UTF-8 text into Base16, Base32, Base64, or Base85.
- Introduce a `decode` command to convert Base16, Base32, Base64, or Base85 encoded text back to UTF-8.
- Define a `CODING_SYSTEMS` mapping and helper functions for supported encoding and decoding operations.

Enhancements:
- Wrap command responses to disable mentions and generate usage text automatically via `generate_usage`.