### PR TITLE
refactor(tempvc): use list comprehensions, add TEMPVC_BASE_NAME

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -65,6 +65,7 @@ USER_IDS:
 TEMPVC_CATEGORY_ID: 123456789012345679
 # Set this to the channel ID where you want the temporary voice channels to be created.
 TEMPVC_CHANNEL_ID: 123456789012345679
+TEMPVC_BASE_NAME: "/tmp/"
 
 # This will automatically give people with a status regex a role.
 STATUS_ROLES:

--- a/tux/cogs/services/temp_vc.py
+++ b/tux/cogs/services/temp_vc.py
@@ -8,7 +8,7 @@ from tux.utils.config import CONFIG
 class TempVc(commands.Cog):
     def __init__(self, bot: Tux) -> None:
         self.bot = bot
-        self.base_vc_name: str = "/tmp/"
+        self.base_vc_name: str = CONFIG.TEMPVC_BASE_NAME or "/tmp/"
 
     @commands.Cog.listener()
     async def on_voice_state_update(

--- a/tux/utils/config.py
+++ b/tux/utils/config.py
@@ -132,6 +132,7 @@ class Config:
     # Temp VC
     TEMPVC_CATEGORY_ID: Final[str | None] = config["TEMPVC_CATEGORY_ID"]
     TEMPVC_CHANNEL_ID: Final[str | None] = config["TEMPVC_CHANNEL_ID"]
+    TEMPVC_BASE_NAME: Final[str | None] = config["TEMPVC_BASE_NAME"]
 
     # GIF ratelimiter
     RECENT_GIF_AGE: Final[int] = config["GIF_LIMITER"]["RECENT_GIF_AGE"]


### PR DESCRIPTION
## Description

### TEMPVC_BASE_NAME
This adds a new config variable called TEMPVC_BASE_NAME which will allow an admin to change the default temporary VC channel base name. This will allow for better customisabillity in Tux which I see as an end goal of the project. I have also added it to the example.

## Guidelines

- [x] My code follows the style guidelines of this project (formatted with Ruff)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] My changes generate no new warnings
- [x] I have tested this change
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have added all appropriate labels to this PR

- [ ] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

I joined a channel after changing the value and it had the exact value I expected.

## Screenshots (if applicable)

`TEMPVC_BASE_NAME: "tmp: "`

<img width="333" height="91" alt="{67BE70DB-4F2A-46E3-9ABA-26E8B8268AE9}" src="https://github.com/user-attachments/assets/55d97b12-da4b-4f91-8086-bf2143bbe36b" />

`TEMPVC_BASE_NAME: "new value "`

<img width="340" height="83" alt="{F710A719-CE0B-4999-B0AC-DF743C6BA7FD}" src="https://github.com/user-attachments/assets/68202935-5447-4e1b-97f9-4b72d4cd54c9" />

## Summary by Sourcery

Enable customization of temporary voice channel base names by adding and using a new TEMPVC_BASE_NAME configuration option

New Features:
- Introduce TEMPVC_BASE_NAME config variable to customize the default base name for temporary voice channels

Enhancements:
- Update TempVc cog to use TEMPVC_BASE_NAME with a fallback to "/tmp/"

Documentation:
- Add TEMPVC_BASE_NAME to the example settings file