### PR TITLE
refactor(treewide): reorder statements to improve speed

### DIFF
--- a/tux/cogs/fun/xkcd.py
+++ b/tux/cogs/fun/xkcd.py
@@ -35,10 +35,11 @@ class Xkcd(commands.Cog):
             The ID of the xkcd comic to search for.
         """
 
-        if comic_id:
-            await self.specific(ctx, comic_id)
-        else:
+        if not comic_id:
             await ctx.send_help("xkcd")
+            return
+
+        await self.specific(ctx, comic_id)
 
     @xkcd.command(
         name="latest",

--- a/tux/cogs/info/avatar.py
+++ b/tux/cogs/info/avatar.py
@@ -75,22 +75,16 @@ class Avatar(commands.Cog):
         member : discord.Member
             The member to get the avatar of.
         """
-        if member is not None:
+        if isinstance(source, discord.Interaction) and member is not None:
             guild_avatar = member.guild_avatar.url if member.guild_avatar else None
             global_avatar = member.avatar.url if member.avatar else None
             files = [await self.create_avatar_file(avatar) for avatar in [guild_avatar, global_avatar] if avatar]
 
             if files:
-                if isinstance(source, discord.Interaction):
-                    await source.response.send_message(files=files)
-                else:
-                    await source.reply(files=files)
+                await source.response.send_message(files=files)
             else:
                 message = "Member has no avatar."
-                if isinstance(source, discord.Interaction):
-                    await source.response.send_message(content=message, ephemeral=True, delete_after=30)
-                else:
-                    await source.reply(content=message, ephemeral=True, delete_after=30)
+                await source.response.send_message(content=message, ephemeral=True, delete_after=30)
 
         elif isinstance(source, commands.Context):
             member = await commands.MemberConverter().convert(source, str(source.author.id))


### PR DESCRIPTION
## Description

This refactors the tree to optimise the cog loader, the `avatar` command and the `xkcd` command with reordered if statements, and storing variables to remove unnecessary function calls. I think this is clean enough at the moment for me to write this as a PR. There will of course still be some unoptimal things I have missed but I cannot seem to find any that wouldn't conflict with #853.

## Guidelines

- [x] My code follows the style guidelines of this project (formatted with Ruff)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [x] My changes generate no new warnings
- [x] I have tested this change
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added all appropriate labels to this PR

- [ ] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

I started Tux and ran a few commands.

## Screenshots (if applicable)

<img width="512" height="551" alt="{DA6308F5-4136-4C22-A265-C737785F4DC8}" src="https://github.com/user-attachments/assets/95d8c585-639d-438a-8318-3243501ade97" />

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Refactor sentry span tagging and command handlers to reduce redundant calls and simplify control flows

Enhancements:
- Cache sentry initialization status in a module-level variable to eliminate repeated is_initialized calls in cog_loader
- Reorder and combine SENTRY_INITIALIZED checks around span tagging to streamline cog loading observability
- Simplify avatar command logic by consolidating interaction response paths and removing duplicate branches
- Refactor xkcd command to use an early return for missing comic_id and reorder specific comic handling