### PR TITLE
docs: remove command group bot

### DIFF
--- a/docs/content/dev/cli/index.md
+++ b/docs/content/dev/cli/index.md
@@ -11,10 +11,10 @@ The `tux` CLI defaults to **development mode** for all command groups (`db`, `de
 
     ```bash
     # Example: Apply migrations to production database
-    poetry run tux --prod db migrate
+    poetry run tux db migrate --prod
 
     # Example: Start the bot using production token/DB
-    poetry run tux --prod start
+    poetry run tux start --prod
     ```
 
 * **Development Mode (Default / Explicit):**
@@ -23,10 +23,10 @@ The `tux` CLI defaults to **development mode** for all command groups (`db`, `de
     ```bash
     # These are equivalent and run in development mode:
     poetry run tux db push
-    poetry run tux --dev db push
+    poetry run tux db push --dev
 
     poetry run tux start
-    poetry run tux --dev start
+    poetry run tux start --dev
     ```
 
 This default-to-development approach prioritizes safety by preventing accidental operations on production environments. The environment determination logic can be found in `tux/utils/env.py`.

--- a/docs/content/dev/cli/index.md
+++ b/docs/content/dev/cli/index.md
@@ -4,7 +4,7 @@ This section provides details on using the custom `tux` command-line interface, 
 
 ## Environment Selection
 
-The `tux` CLI defaults to **development mode** for all command groups (`bot`, `db`, `dev`, `docker`). This ensures that operations like database migrations or starting the bot target your development resources unless explicitly specified otherwise.
+The `tux` CLI defaults to **development mode** for all command groups (`db`, `dev`, `docker`). This ensures that operations like database migrations or starting the bot target your development resources unless explicitly specified otherwise.
 
 * **Production Mode:**
     To run a command targeting production resources (e.g., production database, production bot token), you **must** use the global `--prod` flag immediately after `tux`:
@@ -14,7 +14,7 @@ The `tux` CLI defaults to **development mode** for all command groups (`bot`, `d
     poetry run tux --prod db migrate
 
     # Example: Start the bot using production token/DB
-    poetry run tux --prod bot start
+    poetry run tux --prod start
     ```
 
 * **Development Mode (Default / Explicit):**
@@ -25,8 +25,8 @@ The `tux` CLI defaults to **development mode** for all command groups (`bot`, `d
     poetry run tux db push
     poetry run tux --dev db push
 
-    poetry run tux bot start
-    poetry run tux --dev bot start
+    poetry run tux start
+    poetry run tux --dev start
     ```
 
 This default-to-development approach prioritizes safety by preventing accidental operations on production environments. The environment determination logic can be found in `tux/utils/env.py`.


### PR DESCRIPTION
## Description

Fixes a documentation error in relation to the `bot` command group

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Please describe how you tested your code. e.g describe what commands you ran, what arguments, and any config stuff (if applicable)

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Documentation:
- Remove `bot` from the list of default CLI command groups and update example commands to use `start` directly