### PR TITLE
fix: Ensure the bookmarks service will only delete messages in DMs

### DIFF
--- a/tux/cogs/services/bookmarks.py
+++ b/tux/cogs/services/bookmarks.py
@@ -73,8 +73,12 @@ class Bookmarks(commands.Cog):
         if payload.emoji.name in self.add_bookmark_emojis:
             await self.add_bookmark(user, message)
 
+        # Ensures were in a users DMs before removing (to fix an issue with being able to remove messages anywhere)
+        if not isinstance(channel, discord.DMChannel):
+            return
+
         # If the emoji is the remove bookmark emoji, remove the bookmark
-        elif payload.emoji.name in self.remove_bookmark_emojis:
+        if payload.emoji.name in self.remove_bookmark_emojis:
             await self.remove_bookmark(message)
 
     async def add_bookmark(self, user: discord.User, message: discord.Message) -> None:

--- a/tux/cogs/services/bookmarks.py
+++ b/tux/cogs/services/bookmarks.py
@@ -77,8 +77,8 @@ class Bookmarks(commands.Cog):
         if not isinstance(channel, discord.DMChannel):
             return
 
-        # If the emoji is the remove bookmark emoji, remove the bookmark
-        if payload.emoji.name in self.remove_bookmark_emojis:
+        # If the emoji is the remove bookmark emoji and reaction is on the bot, remove the bookmark
+        if payload.emoji.name in self.remove_bookmark_emojis and message.author is self.bot.user:
             await self.remove_bookmark(message)
 
     async def add_bookmark(self, user: discord.User, message: discord.Message) -> None:


### PR DESCRIPTION
## Description

Added some additional checks to ensure only messages from Tux can only be deleted in DMs. previously it was possible for any user (even without elevated permissions) to delete any message in the server that the bot was active in.

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

I tested both on an account who owned the server and one without any permissions and made sure both could delete the Tux DM messages

## Summary by Sourcery

Restrict bookmark removal to direct messages and bot-authored messages by adding channel type and author checks.

Bug Fixes:
- Prevent bookmark removals in non-DM channels by returning early if the channel is not a DMChannel
- Ensure the remove bookmark emoji only deletes messages authored by the bot