### PR TITLE
fix: enable the banning nonserver users

### DIFF
--- a/tux/cogs/moderation/ban.py
+++ b/tux/cogs/moderation/ban.py
@@ -21,7 +21,7 @@ class Ban(ModerationCogBase):
     async def ban(
         self,
         ctx: commands.Context[Tux],
-        member: discord.Member,
+        user: discord.User,
         *,
         flags: BanFlags,
     ) -> None:
@@ -48,19 +48,19 @@ class Ban(ModerationCogBase):
         assert ctx.guild
 
         # Check if moderator has permission to ban the member
-        if not await self.check_conditions(ctx, member, ctx.author, "ban"):
+        if not await self.check_conditions(ctx, user, ctx.author, "ban"):
             return
 
         # Execute ban with case creation and DM
         await self.execute_mod_action(
             ctx=ctx,
             case_type=CaseType.BAN,
-            user=member,
+            user=user,
             reason=flags.reason,
             silent=flags.silent,
             dm_action="banned",
             actions=[
-                (ctx.guild.ban(member, reason=flags.reason, delete_message_seconds=flags.purge * 86400), type(None)),
+                (ctx.guild.ban(user, reason=flags.reason, delete_message_seconds=flags.purge * 86400), type(None)),
             ],
         )
 


### PR DESCRIPTION
## Description

Changed ban.py to allow non-server members to be banned previously 

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

tested with an admin account and unprivileged alt both attempting to ban a current guild member and a non-guild member

## Additional Information

it does give a warning for not being able to DM a user (obviously this is because they're not apart of the guild)
i also got a warning for "No guild config found for guild_id" but i am pretty sure this is due to my server

## Summary by Sourcery

Bug Fixes:
- Allow banning of non-server members by changing the ban command parameter to discord.User