### PR TITLE
feat: added uptime and current branch to status

### DIFF
--- a/tux/bot.py
+++ b/tux/bot.py
@@ -62,6 +62,7 @@ class Tux(commands.Bot):
 
         self.emoji_manager = EmojiManager(self)
         self.console = Console(stderr=True, force_terminal=True)
+        self.uptime = discord.utils.utcnow().timestamp()
 
         logger.debug("Creating bot setup task")
         self.setup_task = asyncio.create_task(self.setup(), name="bot_setup")

--- a/tux/cogs/utility/ping.py
+++ b/tux/cogs/utility/ping.py
@@ -44,9 +44,13 @@ class Ping(commands.Cog):
         minutes, seconds = divmod(remainder, 60)
 
         # Format it for the command
-        bot_uptime_readable = " ".join(
-            [f"{days}d" if days else "", f"{hours}h" if hours else "", f"{minutes}m" if minutes else "", f"{seconds}s"],
-        ).strip()
+        bot_uptime_parts = [
+            f"{days}d" if days else "",
+            f"{hours}h" if hours else "",
+            f"{minutes}m" if minutes else "",
+            f"{seconds}s",
+        ]
+        bot_uptime_readable = " ".join(part for part in bot_uptime_parts if part).strip()
 
         # Get the CPU usage and RAM usage of the bot
         cpu_usage = psutil.Process().cpu_percent()


### PR DESCRIPTION
## Description

Add uptime and the current environment (dev/prod) to the ping command aswell as aliasing it to status

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

tested within my discord server while monitoring my tux console

## Screenshots (if applicable)

<img width="479" height="345" alt="image" src="https://github.com/user-attachments/assets/26caa893-eade-4341-beb5-ed53620cc9ae" />

## Summary by Sourcery

Enhance the ping command (aliased as status) to include bot uptime and current environment

New Features:
- Alias the ping command to status
- Display human-readable uptime in the status embed
- Display the current environment (prod/dev) in the status embed

Enhancements:
- Initialize and track bot start timestamp for uptime calculation