### PR TITLE
feat(command): allow irc users to use snippet command

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -115,7 +115,9 @@ GIF_LIMITER: # Limits the amount of gifs a user can send in a channel
   GIF_LIMITS_CHANNEL:
     "123456789012345": 3
 
-IRC: # IDs of the IRC bridge webhooks
+# If you do not have an IRC bridge running, ignore these options
+# Allows messages from these webhooks to use only the $s and $snippet commands (for now)
+IRC:
   BRIDGE_WEBHOOK_IDS:
     - 123456789012345679
     - 123456789012345679

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -114,3 +114,9 @@ GIF_LIMITER: # Limits the amount of gifs a user can send in a channel
     "123456789012345": 2
   GIF_LIMITS_CHANNEL:
     "123456789012345": 3
+
+IRC: # IDs of the IRC bridge webhooks
+  BRIDGE_WEBHOOK_IDS:
+    - 123456789012345679
+    - 123456789012345679
+    - 123456789012345679

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -44,6 +44,8 @@ with patch("pathlib.Path.read_text") as mock_read_text:
     SNIPPETS:
       LIMIT_TO_ROLE_IDS: false
       ACCESS_ROLE_IDS: []
+    IRC:
+      BRIDGE_WEBHOOK_IDS: []
     """
     mock_read_text.return_value = mock_config_content
     import tux.main

--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 from tux.bot import Tux
 from tux.database.controllers import DatabaseController
 from tux.ui.embeds import EmbedCreator, EmbedType
+from tux.utils.config import CONFIG
 from tux.utils.functions import is_harmful, strip_formatting
 
 
@@ -68,6 +69,14 @@ class EventHandler(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
+        # Allow the IRC bridge to use the snippet command only
+        if message.webhook_id in CONFIG.BRIDGE_WEBHOOK_IDS and (
+            message.content.startswith(f"{CONFIG.DEFAULT_PREFIX}s ")
+            or message.content.startswith(f"{CONFIG.DEFAULT_PREFIX}snippet ")
+        ):
+            ctx = await self.bot.get_context(message)
+            await self.bot.invoke(ctx)
+
         await self.handle_harmful_message(message)
 
     @commands.Cog.listener()

--- a/tux/utils/config.py
+++ b/tux/utils/config.py
@@ -153,7 +153,7 @@ class Config:
     ACCESS_ROLE_IDS: Final[list[int]] = config["SNIPPETS"]["ACCESS_ROLE_IDS"]
 
     # IRC Bridges
-    BRIDGE_WEBHOOK_IDS: Final[list[int]] = config["IRC"]["BRIDGE_WEBHOOK_IDS"]
+    BRIDGE_WEBHOOK_IDS: Final[list[int]] = [int(x) for x in config["IRC"]["BRIDGE_WEBHOOK_IDS"]]
 
 
 CONFIG = Config()

--- a/tux/utils/config.py
+++ b/tux/utils/config.py
@@ -152,5 +152,8 @@ class Config:
     LIMIT_TO_ROLE_IDS: Final[bool] = config["SNIPPETS"]["LIMIT_TO_ROLE_IDS"]
     ACCESS_ROLE_IDS: Final[list[int]] = config["SNIPPETS"]["ACCESS_ROLE_IDS"]
 
+    # IRC Bridges
+    BRIDGE_WEBHOOK_IDS: Final[list[int]] = config["IRC"]["BRIDGE_WEBHOOK_IDS"]
+
 
 CONFIG = Config()


### PR DESCRIPTION
## Description
Allows users from the IRC to run snippet command via the bridge

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Created webhook in test server and ran snippet command and help command. only snippet command worked

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.
context as to why its only the snippet command: https://discord.com/channels/1184229800332771328/1273687471732949085/1400580384105955338

## Summary by Sourcery

Enable the snippet command for users messaging through an IRC bridge by whitelisting specific webhook IDs and adding the corresponding configuration option.

New Features:
- Allow IRC-bridged messages to invoke the snippet command

Enhancements:
- Add BRIDGE_WEBHOOK_IDS configuration for IRC bridge webhooks

Documentation:
- Update example settings.yml with IRC BRIDGE_WEBHOOK_IDS