### PR TITLE
fix: replace CheckFailure with PermissionLevelError in SnippetsBaseCog

### DIFF
--- a/tux/cogs/snippets/__init__.py
+++ b/tux/cogs/snippets/__init__.py
@@ -10,6 +10,7 @@ from tux.ui.embeds import EmbedCreator, EmbedType
 from tux.utils import checks
 from tux.utils.config import Config
 from tux.utils.constants import CONST
+from tux.utils.exceptions import PermissionLevelError
 
 
 class SnippetsBaseCog(commands.Cog):
@@ -109,7 +110,8 @@ class SnippetsBaseCog(commands.Cog):
         """Check if the user invoking the command has moderator permissions (PL >= configured level)."""
         try:
             await checks.has_pl(2).predicate(ctx)
-        except commands.CheckFailure:
+        except PermissionLevelError:
+            # this happens if the user is not a mod
             return False
         except Exception as e:
             logger.error(f"Unexpected error in check_if_user_has_mod_override: {e}")


### PR DESCRIPTION
## Description

fixes an issue where users cant make snippets if they arent a mod

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

had an user who wasnt a mod make a snippet before and after, worked after

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Bug Fixes:
- Replace commands.CheckFailure with PermissionLevelError in SnippetsBaseCog's permission check so non-mod users can create snippets