### PR TITLE
fix(harmful command): check irc bridge messages too

### DIFF
--- a/tux/handlers/event.py
+++ b/tux/handlers/event.py
@@ -36,7 +36,7 @@ class EventHandler(commands.Cog):
         None
         """
 
-        if message.author.bot:
+        if message.author.bot and message.webhook_id not in CONFIG.BRIDGE_WEBHOOK_IDS:
             return
 
         stripped_content = strip_formatting(message.content)


### PR DESCRIPTION
## Description

Makes it so the warning message is also sent when a message is coming from the IRC bridge

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)
see below

## Screenshots (if applicable)


<img width="2499" height="302" alt="image" src="https://github.com/user-attachments/assets/f20c94fe-6bc9-4fcc-a0c7-e6ce0d5db8ab" />

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Bug Fixes:
- Allow harmful command detection to apply to messages from the IRC bridge