### PR TITLE
build: switch to basedpyright

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
     "vscode": {
       "extensions": [
         "ms-python.python",
-        "ms-python.vscode-pylance",
+        "detachhead.basedpyright",
         "charliermarsh.ruff",
         "prisma.prisma",
         "kevinrose.vsc-python-indent",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -169,7 +169,7 @@ Follow these steps to set up your local development environment. For more compre
     # Lint code using Ruff
     poetry run tux dev lint-fix
 
-    # Type-check code using Pyright
+    # Type-check code using basedpyright
     poetry run tux dev type-check
 
     # Run all pre-commit checks (includes formatting, linting, etc.)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       # basedpyright provides comprehensive type checking for Python
       # Annotations appear directly in PR for developer feedback
       - name: Run basedpyright type checker
-        run: basedpyright
+        run: poetry run basedpyright
 
   # ============================================================================
   # MARKDOWN DOCUMENTATION LINTING

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@
 # ------------------
 # 1. Smart file change detection to skip unnecessary jobs
 # 2. Parallel execution for different linting categories
-# 3. Comprehensive Python static analysis with Pyright
+# 3. Comprehensive Python static analysis with basedpyright
 # 4. Infrastructure validation (Docker, GitHub Actions, Shell)
 # 5. Markdown linting for documentation quality
 # 6. Efficient caching to reduce execution time
@@ -62,7 +62,7 @@ jobs:
   # PYTHON QUALITY CHECKS - Static Analysis and Type Checking
   # ============================================================================
   # Purpose: Ensures Python code quality through static analysis and type checking
-  # Tools: Pyright type checker with Poetry dependency management
+  # Tools: Basedpyright type checker with Poetry dependency management
   # Optimization: Only runs when Python files or dependencies change
   # ============================================================================
   python:
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read          # Required for checkout
-      pull-requests: write   # Required for Pyright annotations
+      pull-requests: write   # Required for basedpyright annotations
     steps:
       # REPOSITORY CHECKOUT
       # Full history needed for accurate change detection
@@ -115,14 +115,10 @@ jobs:
           generate-prisma: 'true'
 
       # STATIC TYPE CHECKING
-      # Pyright provides comprehensive type checking for Python
+      # basedpyright provides comprehensive type checking for Python
       # Annotations appear directly in PR for developer feedback
-      - name: Run Pyright type checker
-        if: steps.python_changes.outputs.any_changed == 'true' || github.event_name
-          == 'workflow_dispatch'
-        uses: jakebailey/pyright-action@b5d50e5cde6547546a5c4ac92e416a8c2c1a1dfe # v2
-        with:
-          annotate: errors
+      - name: Run basedpyright type checker
+        run: basedpyright
 
   # ============================================================================
   # MARKDOWN DOCUMENTATION LINTING

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
     "EditorConfig.EditorConfig",
     "ms-vscode-remote.remote-containers",
     "ms-python.python",
-    "ms-python.vscode-pylance",
+    "detachhead.basedpyright",
     "ms-azuretools.vscode-docker",
     "charliermarsh.ruff",
     "prisma.prisma",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,8 +11,9 @@
       "source.organizeImports.ruff": "explicit"
     }
   },
-  "python.languageServer": "Pylance",
-  "python.analysis.typeCheckingMode": "strict",
+  "python.analysis.typeCheckingMode": "off",
+  "cursorpyright.analysis.typeCheckMode": "off",
+  "python.languageServer": "None",
   "python.analysis.autoFormatStrings": true,
   "python.analysis.completeFunctionParens": true,
   "python.analysis.autoImportCompletions": true,

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It is designed to provide a variety of features to the server, including moderat
 - Python 3.13+ alongside the `discord.py` library
 - Poetry for dependency management
 - Docker and Docker Compose for optional containerized environments
-- Strict typing with `pyright` and type hints
+- Strict typing with `basedpyright` and type hints
 - Type safe ORM using `prisma`
 - Linting and formatting via `ruff`
 - Custom CLI via `click` and `poetry` scripts

--- a/poetry.lock
+++ b/poetry.lock
@@ -345,6 +345,21 @@ files = [
 extras = ["regex"]
 
 [[package]]
+name = "basedpyright"
+version = "1.29.5"
+description = "static type checking for Python (but based)"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "basedpyright-1.29.5-py3-none-any.whl", hash = "sha256:e7eee13bec8b3c20d718c6f3ef1e2d57fb04621408e742aa8c82a1bd82fe325b"},
+    {file = "basedpyright-1.29.5.tar.gz", hash = "sha256:468ad6305472a2b368a1f383c7914e9e4ff3173db719067e1575cf41ed7b5a36"},
+]
+
+[package.dependencies]
+nodejs-wheel-binaries = ">=20.13.1"
+
+[[package]]
 name = "braceexpand"
 version = "0.1.7"
 description = "Bash-style brace expansion for Python"
@@ -2448,6 +2463,23 @@ files = [
 ]
 
 [[package]]
+name = "nodejs-wheel-binaries"
+version = "22.18.0"
+description = "unoffical Node.js package"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "nodejs_wheel_binaries-22.18.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:53b04495857755c5d5658f7ac969d84f25898fe0b0c1bdc41172e5e0ac6105ca"},
+    {file = "nodejs_wheel_binaries-22.18.0-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bd4d016257d4dfe604ed526c19bd4695fdc4f4cc32e8afc4738111447aa96d03"},
+    {file = "nodejs_wheel_binaries-22.18.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3b125f94f3f5e8ab9560d3bd637497f02e45470aeea74cf6fe60afe751cfa5f"},
+    {file = "nodejs_wheel_binaries-22.18.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78bbb81b6e67c15f04e2a9c6c220d7615fb46ae8f1ad388df0d66abac6bed5f8"},
+    {file = "nodejs_wheel_binaries-22.18.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5d3ea8b7f957ae16b73241451f6ce831d6478156f363cce75c7ea71cbe6c6f7"},
+    {file = "nodejs_wheel_binaries-22.18.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bcda35b07677039670102a6f9b78c2313fd526111d407cb7ffc2a4c243a48ef9"},
+    {file = "nodejs_wheel_binaries-22.18.0-py2.py3-none-win_amd64.whl", hash = "sha256:0f55e72733f1df2f542dce07f35145ac2e125408b5e2051cac08e5320e41b4d1"},
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
@@ -3186,27 +3218,6 @@ files = [
     {file = "pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"},
     {file = "pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"},
 ]
-
-[[package]]
-name = "pyright"
-version = "1.1.403"
-description = "Command line wrapper for pyright"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3"},
-    {file = "pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104"},
-]
-
-[package.dependencies]
-nodeenv = ">=1.6.0"
-typing-extensions = ">=4.1"
-
-[package.extras]
-all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
-dev = ["twine (>=3.4.1)"]
-nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
@@ -4817,4 +4828,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13.2,<3.14"
-content-hash = "d1c6d35ccc769d6897f30c3fa37a7708b15bb47c93351f0ceaf072eee61af74e"
+content-hash = "9b4d3ec68b13f56e917fdde753dda9b88c85e337e830a7803362f523b4bffe86"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ jinja2 = "^3.1.6"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "==4.2.0"
-pyright = "==1.1.403"
+basedpyright = "==1.29.5" # currently downgraded due to https://github.com/DetachHead/basedpyright/issues/1395
 ruff = "==0.12.7"
 poetry-types = "0.6.0"
 yamllint = "1.37.1"
@@ -150,7 +150,7 @@ line-ending = "lf"
 quote-style = "double"
 skip-magic-trailing-comma = false
 
-[tool.pyright]
+[tool.basedpyright]
 defineConstant = { DEBUG = true }
 enableReachabilityAnalysis = true
 exclude = ["__pypackages__", "_build", "examples", ".archive", "typings/**"]
@@ -160,6 +160,7 @@ stubPath = "typings"
 pythonPlatform = "Linux"
 pythonVersion = "3.13"
 reportImportCycles = true
+reportRedeclaration = false
 strictDictionaryInference = true
 strictListInference = true
 strictSetInference = true

--- a/tux/cli/dev.py
+++ b/tux/cli/dev.py
@@ -30,8 +30,8 @@ def format_code() -> int:
 
 @command_registration_decorator(dev_group, name="type-check")
 def type_check() -> int:
-    """Check types with Pyright."""
-    return run_command(["pyright"])
+    """Check types with basedpyright."""
+    return run_command(["basedpyright"])
 
 
 @command_registration_decorator(dev_group, name="pre-commit")


### PR DESCRIPTION
## Description

basedpyright allows for a lot of nicer features, one of the main ones being significantly better compatibility with non vscode editors
see https://docs.basedpyright.com/latest/ and the "Benefits over pyright" section on the documentation for more info

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

ran `basedpyright` to check types

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Switch from Pyright to BasedPyright for static type checking across the project

Enhancements:
- Adopt BasedPyright to improve compatibility with non-VS Code editors

Build:
- Update GitHub Actions CI to run BasedPyright instead of Pyright

Documentation:
- Revise documentation and contributing guidelines to refer to BasedPyright instead of Pyright

Chores:
- Replace Pyright dependency and configuration in pyproject.toml and tool config
- Update local CLI command to invoke BasedPyright for type checks