### PR TITLE
fix(moderation): fix ban check

### DIFF
--- a/tux/cogs/moderation/ban.py
+++ b/tux/cogs/moderation/ban.py
@@ -21,7 +21,7 @@ class Ban(ModerationCogBase):
     async def ban(
         self,
         ctx: commands.Context[Tux],
-        user: discord.User,
+        member: discord.Member | discord.User,
         *,
         flags: BanFlags,
     ) -> None:
@@ -32,7 +32,7 @@ class Ban(ModerationCogBase):
         ----------
         ctx : commands.Context[Tux]
             The context in which the command is being invoked.
-        member : discord.Member
+        member : discord.Member | discord.User
             The member to ban.
         flags : BanFlags
             The flags for the command. (reason: str, purge: int (< 7), silent: bool)
@@ -48,19 +48,19 @@ class Ban(ModerationCogBase):
         assert ctx.guild
 
         # Check if moderator has permission to ban the member
-        if not await self.check_conditions(ctx, user, ctx.author, "ban"):
+        if not await self.check_conditions(ctx, member, ctx.author, "ban"):
             return
 
         # Execute ban with case creation and DM
         await self.execute_mod_action(
             ctx=ctx,
             case_type=CaseType.BAN,
-            user=user,
+            user=member,
             reason=flags.reason,
             silent=flags.silent,
             dm_action="banned",
             actions=[
-                (ctx.guild.ban(user, reason=flags.reason, delete_message_seconds=flags.purge * 86400), type(None)),
+                (ctx.guild.ban(member, reason=flags.reason, delete_message_seconds=flags.purge * 86400), type(None)),
             ],
         )
 


### PR DESCRIPTION
## Description

because the variable is no longer `discord.Member` type and this check:
```py
        # Role hierarchy check - only applies when both are Members
        elif (
            isinstance(user, discord.Member)
            and isinstance(moderator, discord.Member)
            and user.top_role >= moderator.top_role
        ):
            fail_reason = f"You cannot {action} a user with a higher or equal role."
```
requires it to be a member this check doesnt work anymore

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

had my alt try to ban me, then banned my alt, then unbanned it, then banned it again to check if banning outside of server works

## Summary by Sourcery

Update ban command to accept both discord.Member and discord.User by adjusting parameter types and calls, restoring permission and role hierarchy checks

Bug Fixes:
- Fix ban permission check by passing the correct member parameter to check_conditions and guild.ban

Enhancements:
- Change ban command signature and docstring to use member parameter typed as discord.Member|discord.User