### PR TITLE
fix: Made the encode and decode commands more descriptive

### DIFF
--- a/tux/cogs/utility/encode_decode.py
+++ b/tux/cogs/utility/encode_decode.py
@@ -160,6 +160,7 @@ class EncodeDecode(commands.Cog):
         except binascii.Error as e:
             await ctx.reply(
                 content=f"Decoding error: {e}",
+                ephemeral=True,
             )
             return
         except UnicodeDecodeError:

--- a/tux/cogs/utility/encode_decode.py
+++ b/tux/cogs/utility/encode_decode.py
@@ -1,7 +1,7 @@
 import base64
 import binascii
 
-from discord import AllowedMentions
+from discord import AllowedMentions, app_commands
 from discord.ext import commands
 
 from tux.bot import Tux
@@ -44,16 +44,23 @@ class EncodeDecode(commands.Cog):
         await ctx.reply(
             content=data,
             allowed_mentions=allowed_mentions,
-            ephemeral=False,
+            ephemeral=True,
         )
 
-    @commands.hybrid_command(
-        name="encode",
+    @commands.hybrid_command(name="encode", aliases=["ec"], description="Encode a message")
+    @app_commands.describe(text="Text to encode")
+    @app_commands.choices(
+        codesystem=[
+            app_commands.Choice(name="base16", value="base16"),
+            app_commands.Choice(name="base32", value="base32"),
+            app_commands.Choice(name="base64", value="base64"),
+            app_commands.Choice(name="base85", value="base85"),
+        ],
     )
     async def encode(
         self,
         ctx: commands.Context[Tux],
-        cs: str,
+        codesystem: str,
         *,
         text: str,
     ) -> None:
@@ -64,23 +71,23 @@ class EncodeDecode(commands.Cog):
         ----------
         ctx : commands.Context[Tux]
             The context of the command.
-        cs : str
+        codesystem : str
             The coding system.
         text : str
             The text you want to encode.
         """
 
-        cs = cs.lower()
+        codesystem = codesystem.lower()
         btext = text.encode(encoding="utf-8")
 
         try:
-            if cs == "base16":
+            if codesystem == "base16":
                 data = base64.b16encode(btext)
-            elif cs == "base32":
+            elif codesystem == "base32":
                 data = base64.b32encode(btext)
-            elif cs == "base64":
+            elif codesystem == "base64":
                 data = base64.b64encode(btext)
-            elif cs == "base85":
+            elif codesystem == "base85":
                 data = base64.b85encode(btext)
             else:
                 await ctx.reply(
@@ -98,13 +105,21 @@ class EncodeDecode(commands.Cog):
                 ephemeral=True,
             )
 
-    @commands.hybrid_command(
-        name="decode",
+    @commands.hybrid_command(name="decode", aliases=["dc"], description="Decode a message")
+    @app_commands.describe(codesystem="Which Coding System to use")
+    @app_commands.describe(text="Text to decode")
+    @app_commands.choices(
+        codesystem=[
+            app_commands.Choice(name="base16", value="base16"),
+            app_commands.Choice(name="base32", value="base32"),
+            app_commands.Choice(name="base64", value="base64"),
+            app_commands.Choice(name="base85", value="base85"),
+        ],
     )
     async def decode(
         self,
         ctx: commands.Context[Tux],
-        cs: str,
+        codesystem: str,
         *,
         text: str,
     ) -> None:
@@ -115,23 +130,23 @@ class EncodeDecode(commands.Cog):
         ----------
         ctx : commands.Context[Tux]
             The context of the command.
-        cs : str
+        codesystem : str
             The coding system.
         text : str
             The text you want to decode.
         """
 
-        cs = cs.lower()
+        codesystem = codesystem.lower()
         btext = text.encode(encoding="utf-8")
 
         try:
-            if cs == "base16":
+            if codesystem == "base16":
                 data = base64.b16decode(btext)
-            elif cs == "base32":
+            elif codesystem == "base32":
                 data = base64.b32decode(btext)
-            elif cs == "base64":
+            elif codesystem == "base64":
                 data = base64.b64decode(btext)
-            elif cs == "base85":
+            elif codesystem == "base85":
                 data = base64.b85decode(btext)
             else:
                 await ctx.reply(


### PR DESCRIPTION
## Description

Added Descriptions to the command options as well as replacing "cs" with "codesystem" for the entire file
also added predefined options for the codesystem flag and fixed other issues mentioned in issue #1005
 
## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Tested on my own Tux instance by using the command in various ways

## Screenshots (if applicable)
<img width="451" height="287" alt="image" src="https://github.com/user-attachments/assets/14231c79-4e27-432f-bb3a-fdcea83b268c" />
<img width="178" height="59" alt="image" src="https://github.com/user-attachments/assets/83d39581-bbc7-4601-82ff-0d1a66fe9453" />

## Summary by Sourcery

Enhance encode and decode commands with clearer parameter naming, help descriptions, command aliases, and predefined encoding choices; make bot replies ephemeral by default.

Bug Fixes:
- Set ephemeral parameter to True for send_message replies

Enhancements:
- Rename cs parameter to codesystem across encode and decode commands
- Add descriptive help texts for commands and parameters and predefined choices for codesystem option
- Introduce "ec" and "dc" aliases for the encode and decode commands