### PR TITLE
fix: prevent others from interacting with the help command

### DIFF
--- a/tux/ui/help_components.py
+++ b/tux/ui/help_components.py
@@ -50,6 +50,14 @@ class BaseHelpView(discord.ui.View):
     def __init__(self, help_command: HelpCommandProtocol, timeout: int = 180):
         super().__init__(timeout=timeout)
         self.help_command = help_command
+        self.author = help_command.context.author
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """Ensure only the invoker can interact with this view."""
+        if interaction.user != self.author:
+            await interaction.response.send_message("You can't interact with others help menus!", ephemeral=True)
+            return False
+        return True
 
 
 class BaseSelectMenu(discord.ui.Select[BaseHelpView]):


### PR DESCRIPTION
## Description

Adds a check to ensure only the person who envoked the help command can interact with it (fixes issue #867)


## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Tested on my Tux instance using two accounts

## Screenshots (if applicable)

![37SmIUbnam](https://github.com/user-attachments/assets/614803da-b644-467e-be40-11ae04a961ce)

## Summary by Sourcery

Bug Fixes:
- Add an interaction_check in BaseHelpView to prevent users other than the invoker from interacting with the help menu.