### PR TITLE
fix(help): remove double prefix in 'help' on non-existent command

### DIFF
--- a/tux/help.py
+++ b/tux/help.py
@@ -97,7 +97,7 @@ class TuxHelp(commands.HelpCommand):
             command_attrs={
                 "help": "Lists all commands and sub-commands.",
                 "aliases": ["h", "commands"],
-                "usage": "$help <command> or <sub-command>",
+                "usage": "help <command> or <sub-command>",
             },
         )
 


### PR DESCRIPTION
## Description

"usage" contained prefix, which is added later on, resulting in the prefix showing up twice when '$help' is used on a non-existent command (ie '$help asdfasdfasdf')

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [x] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

personally dont think this is applicable as its more or less a documentation change

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Bug Fixes:
- Remove hardcoded dollar-sign prefix from the help usage description