### PR TITLE
fix(harmfulcommands): Corrected some edge cases

### DIFF
--- a/src/tux/plugins/atl/harmfulcommands.py
+++ b/src/tux/plugins/atl/harmfulcommands.py
@@ -22,11 +22,11 @@ DANGEROUS_RM_COMMANDS = (
     # Privilege escalation prefixes
     r"(?:sudo\s+|doas\s+|run0\s+)?"
     # rm command
-    r"rm\s+"
+    r"\brm\b\s+"
     # rm options
     r"(?:-[frR]+|--force|--recursive|--no-preserve-root|\s+)*"
     # Root/home indicators
-    r"(?:[/\∕~]\s*|\*|"  # noqa: RUF001
+    r"(?:[/\∕~/.]\s*|\*|"  # noqa: RUF001
     # Critical system paths
     r"/(?:bin|boot|etc|lib|proc|rooin|sys|tmp|usr|var(?:/log)?|network\.|system))"
     # Additional dangerous flags

--- a/src/tux/plugins/atl/harmfulcommands.py
+++ b/src/tux/plugins/atl/harmfulcommands.py
@@ -26,7 +26,7 @@ DANGEROUS_RM_COMMANDS = (
     # rm options
     r"(?:-[frR]+|--force|--recursive|--no-preserve-root|\s+)*"
     # Root/home indicators
-    r"(?:[/\∕~/.]\s*|\*|"  # noqa: RUF001
+    r"(?:[/\∕~]\s*|\.(?:/|\.)\s*|\*|"  # noqa: RUF001
     # Critical system paths
     r"/(?:bin|boot|etc|lib|proc|rooin|sys|tmp|usr|var(?:/log)?|network\.|system))"
     # Additional dangerous flags


### PR DESCRIPTION
# Pull Request

## Description

If your PR is related to an issue, please include the issue number below:

**Related Issue:** Closes #1125 #786 

**Type of Change:**

- [X] Bug fix (non-breaking change which fixes an issue)

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

tested by sending various messages with the problems described in the issues (see screenshots)

## Screenshots (if applicable)
<img width="414" height="565" alt="image" src="https://github.com/user-attachments/assets/6d26b40b-579a-4eb0-a003-a8885cc27e16" />


## Additional Information

"rm -rf ." wouldn't work on pretty much any linux and or unix-like system but i left it in just incase (and it keeps the code cleaner)

## Summary by Sourcery

Tighten harmful command detection for dangerous rm usages to cover additional edge cases.

Bug Fixes:
- Ensure harmful-command detection only triggers on rm as a standalone command token.
- Expand detection of dangerous rm targets to include paths starting with a dot (e.g., ./).