### PR TITLE
fix(levels): restore XP level roles on member rejoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * **Cache**: `InMemoryBackend` honors `ttl_sec` on each `set` (and `TTLCache` supports per-entry TTL), matching Valkey semantics so permission and shared caches keep their intended lifetime when Valkey is not configured; entries no longer all expire on the backend default short TTL
 * **Core**: Prefer `asyncio.get_running_loop()` over `get_event_loop()` in database setup, Sentry async flush, hot reload watcher, and database migration plugin
 * **Permission system**: Dictionary-based lookup in `get_command_permission` when resolving parent-command fallback (less work per check)
+* **Levels**: `LEVEL_XP_LEVEL_MISMATCH_RECONCILE_THRESHOLD` centralizes and documents when stored level vs XP-derived level are reconciled (same rule as XP processing and member rejoin role restore)
+* **Event handling**: Member rejoin level role restore catches `discord.DiscordException` with warning and exception type name; other errors still log with full traceback
 
 ### Fixed
 

--- a/src/tux/modules/features/levels.py
+++ b/src/tux/modules/features/levels.py
@@ -19,6 +19,12 @@ from tux.database.models import Levels
 from tux.shared.config import CONFIG
 from tux.ui.embeds import EmbedCreator
 
+# Reconcile stored level vs XP-derived level when |calculated - stored| exceeds this.
+# A drift of 1 is tolerated (rounding when mapping XP <-> level); larger drift usually
+# means exponent/config changes or inconsistent DB state. Keep in sync with member
+# rejoin role restore in EventHandler.on_member_join.
+LEVEL_XP_LEVEL_MISMATCH_RECONCILE_THRESHOLD: int = 1
+
 
 class LevelsService(BaseCog):
     """Service for managing user levels and XP in Discord guilds."""
@@ -132,7 +138,10 @@ class LevelsService(BaseCog):
         expected_level_from_xp = self.calculate_level(current_xp)
 
         # If stored level doesn't match calculated level, log and use calculated level
-        if abs(expected_level_from_xp - current_level) > 1:
+        if (
+            abs(expected_level_from_xp - current_level)
+            > LEVEL_XP_LEVEL_MISMATCH_RECONCILE_THRESHOLD
+        ):
             logger.warning(
                 f"Level mismatch detected for {member.name} ({member.id}): "
                 f"Stored level: {current_level}, Calculated from XP ({current_xp:.2f}): {expected_level_from_xp}, "

--- a/src/tux/services/handlers/event.py
+++ b/src/tux/services/handlers/event.py
@@ -1,4 +1,4 @@
-"""Event handlers for Tux Bot such as on ready, on guild join, on guild remove, on message and on guild channel create."""
+"""Event handlers for Tux Bot such as on ready, on guild join, on guild remove, on member join (level role restore), on message and on guild channel create."""
 
 import discord
 from discord.ext import commands
@@ -7,11 +7,12 @@ from loguru import logger
 from tux.core.base_cog import BaseCog
 from tux.core.bot import Tux
 from tux.core.permission_system import get_permission_system
+from tux.modules.features.levels import LevelsService
 from tux.shared.config import CONFIG
 
 
 class EventHandler(BaseCog):
-    """Event handlers for Tux Bot such as on ready, on guild join, on guild remove, on message and on guild channel create."""
+    """Event handlers for on_ready, guild join/remove, member join (level role restore), on_message, and guild channel create."""
 
     def __init__(self, bot: Tux) -> None:
         """
@@ -113,6 +114,53 @@ class EventHandler(BaseCog):
 
         # Initialize basic guild data (permissions only)
         await self.bot.db.guild_config.update_onboarding_stage(guild.id, "not_started")
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member) -> None:
+        """Re-apply XP level roles when a member rejoins with existing level data."""
+        if member.bot:
+            return
+
+        levels_cog = self.bot.get_cog("LevelsService")
+        if not isinstance(levels_cog, LevelsService):
+            return
+
+        if await self.bot.is_jailed(member.guild.id, member.id):
+            return
+
+        level_data = await self.db.levels.get_user_level_data(
+            member.id,
+            member.guild.id,
+        )
+        if level_data is None or level_data.blacklisted:
+            return
+
+        current_level = level_data.level
+        expected_from_xp = levels_cog.calculate_level(level_data.xp)
+        if abs(expected_from_xp - current_level) > 1:
+            effective_level = expected_from_xp
+        else:
+            effective_level = current_level
+
+        if effective_level <= 0:
+            return
+
+        try:
+            await levels_cog.update_roles(member, member.guild, effective_level)
+        except Exception:
+            logger.exception(
+                "Failed to restore level roles for member {} in guild {}",
+                member.id,
+                member.guild.id,
+            )
+        else:
+            logger.debug(
+                "Restored level roles for {} ({}) at effective level {} in guild {}",
+                member.name,
+                member.id,
+                effective_level,
+                member.guild.id,
+            )
 
     # TODO: Define data expiration policy for guilds
     @commands.Cog.listener()

--- a/src/tux/services/handlers/event.py
+++ b/src/tux/services/handlers/event.py
@@ -7,7 +7,10 @@ from loguru import logger
 from tux.core.base_cog import BaseCog
 from tux.core.bot import Tux
 from tux.core.permission_system import get_permission_system
-from tux.modules.features.levels import LevelsService
+from tux.modules.features.levels import (
+    LEVEL_XP_LEVEL_MISMATCH_RECONCILE_THRESHOLD,
+    LevelsService,
+)
 from tux.shared.config import CONFIG
 
 
@@ -137,7 +140,10 @@ class EventHandler(BaseCog):
 
         current_level = level_data.level
         expected_from_xp = levels_cog.calculate_level(level_data.xp)
-        if abs(expected_from_xp - current_level) > 1:
+        if (
+            abs(expected_from_xp - current_level)
+            > LEVEL_XP_LEVEL_MISMATCH_RECONCILE_THRESHOLD
+        ):
             effective_level = expected_from_xp
         else:
             effective_level = current_level
@@ -147,9 +153,17 @@ class EventHandler(BaseCog):
 
         try:
             await levels_cog.update_roles(member, member.guild, effective_level)
+        except discord.DiscordException as e:
+            logger.warning(
+                "Failed to restore level roles for member {} in guild {} ({}): {}",
+                member.id,
+                member.guild.id,
+                type(e).__name__,
+                e,
+            )
         except Exception:
             logger.exception(
-                "Failed to restore level roles for member {} in guild {}",
+                "Unexpected error restoring level roles for member {} in guild {}",
                 member.id,
                 member.guild.id,
             )


### PR DESCRIPTION
Made-with: Cursor

# Pull Request

## Description

Provide a clear summary of your changes and reference any related issues. Include the motivation behind these changes and list any new dependencies if applicable.

If your PR is related to an issue, please include the issue number below:

**Related Issue:** Closes #656 

**Type of Change:**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements

## Guidelines

- My code follows the style guidelines of this project (formatted with Ruff)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation if needed
- My changes generate no new warnings
- I have tested this change
- Any dependent changes have been merged and published in downstream modules
- I have added all appropriate labels to this PR

- [X] I have followed all of these guidelines.

## How Has This Been Tested? (if applicable)

Please describe how you tested your code. e.g describe what commands you ran, what arguments, and any config stuff (if applicable)

## Screenshots (if applicable)

Please add screenshots to help explain your changes.

## Additional Information

Please add any other information that is important to this PR.

## Summary by Sourcery

Bug Fixes:
- Reapply stored XP-based level roles when non-jailed members with existing level data rejoin a guild, ensuring their roles remain consistent with their effective level.